### PR TITLE
Change main.go line 21, fmt.Fprint() to fmt.Fprintf()

### DIFF
--- a/main.go
+++ b/main.go
@@ -45,6 +45,6 @@ func main() {
 
 	err := Run(*uniqushPushConfFlags, uniqushPushVersion)
 	if err != nil {
-		fmt.Fprint(os.Stderr, "Cannot start: %v\n", err)
+		fmt.Fprintf(os.Stderr, "Cannot start: %v\n", err)
 	}
 }


### PR DESCRIPTION
When /etc/uniqush/uniqush-push.conf doesn't exists, error message print correctly now.
