### PR TITLE
Fix a memory leak

### DIFF
--- a/srv/apns.go
+++ b/srv/apns.go
@@ -809,6 +809,7 @@ func (self *apnsPushService) updateCheckPoint(prefix string) {
 
 func resultCollector(psp *PushServiceProvider, resChan chan<- *apnsResult, c net.Conn) {
 	defer c.Close()
+	defer close(resChan)
 	var bufData [6]byte
 	for {
 		var cmd uint8


### PR DESCRIPTION
When this routine terminates without closing resChan, the go routine reading from resChan gets stuck expecting more input.