### PR TITLE
Add basic Dockerfile and run script for it

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM centos:7
+MAINTAINER Misha Nasledov <misha@nasledov.com>
+
+RUN /usr/bin/yum -y install golang git gcc make mercurial-hgk wget
+
+ENV GOBIN /tmp/bin
+ENV GOPATH /tmp
+
+RUN go get github.com/uniqush/uniqush-push
+
+COPY conf/uniqush-push.conf .
+
+RUN cp /tmp/bin/uniqush-push /usr/bin \
+    && mkdir /etc/uniqush/ \
+    && cp ./uniqush-push.conf /etc/uniqush/ \
+    && sed -i -e 's/localhost/0.0.0.0/' /etc/uniqush/uniqush-push.conf
+
+EXPOSE 9898
+
+CMD ["./bin/uniqush-push"]

--- a/scripts/run-dockerfile.sh
+++ b/scripts/run-dockerfile.sh
@@ -1,0 +1,14 @@
+#!/bin/bash -e
+
+TAG=$( git describe --always )
+
+function finish {
+    docker rm uniqush-push-$TAG
+}
+
+trap finish EXIT
+
+docker build --tag uniqush-build:$TAG .
+docker run \
+       --name=uniqush-push-$TAG \
+       uniqush-build:$TAG


### PR DESCRIPTION
@monnand Saw someone on the mailing list asking for a Dockerfile. Made a really basic one with a run script. It will currently just "go get" uniqush-push but will use the conf/uniqush-push.conf from the working directory, so the user can set the redis db host/port appropriately and such.

I would just use the Redis Dockerfile from dockerhub as I have in the past for playing with this with Docker personally.

In the future maybe it should actually build what's in the current working directory but it gets the ball rolling.