### PR TITLE
Call Finalize() on PushServiceManager if Finalize() is called on PushBackEnd

### DIFF
--- a/pushbackend.go
+++ b/pushbackend.go
@@ -35,6 +35,7 @@ type PushBackEnd struct {
 func (self *PushBackEnd) Finalize() {
 	self.db.FlushCache()
 	close(self.errChan)
+	self.psm.Finalize()
 }
 
 func NewPushBackEnd(psm *PushServiceManager, database PushDatabase, loggers []Logger) *PushBackEnd {


### PR DESCRIPTION
@monnand A colleague figured out this one. We were having issues with the "/stop" API not working when the service is under load on production -- it would only work once I drained enough traffic away.