### PR TITLE
Fix concurrency issues in adm & c2dm discovered by "go vet"

### DIFF
--- a/srv/adm.go
+++ b/srv/adm.go
@@ -429,11 +429,11 @@ func (self *admPushService) Push(psp *PushServiceProvider, dpQueue <-chan *Deliv
 		res.Content = notif
 		res.Provider = psp
 		res.Destination = dp
-		go func() {
+		go func(dp *DeliveryPoint) {
 			res.MsgId, res.Err = admSinglePush(psp, dp, data, notif)
 			resQueue <- res
 			wg.Done()
-		}()
+		}(dp)
 	}
 	wg.Wait()
 }

--- a/srv/c2dm.go
+++ b/srv/c2dm.go
@@ -215,7 +215,7 @@ func (self *c2dmPushService) Push(psp *PushServiceProvider, dpQueue <-chan *Deli
 	wg := new(sync.WaitGroup)
 	for dp := range dpQueue {
 		wg.Add(1)
-		go func() {
+		go func(dp *DeliveryPoint) {
 			res := new(PushResult)
 			res.Provider = psp
 			res.Destination = dp
@@ -228,7 +228,7 @@ func (self *c2dmPushService) Push(psp *PushServiceProvider, dpQueue <-chan *Deli
 			}
 			resQueue <- res
 			wg.Done()
-		}()
+		}(dp)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
Thanks to Tyson Andre for this:

There is a race condition where the loop variable `dp` being iterated
over may be changed before the corresponding goroutine may execute.

We don't use amazon notifications or Google's c2dm(we use gcm instead), so this won't fix any of our concurrency problems.

This was introduced years ago in the upstream code, in 97a19790 and b11f9a19

This type of race condition is mentioned in
https://golang.org/doc/effective_go.html#channels

Detected with the command:

`go tool vet --all=true .`
