### PR TITLE
Fix issue #68 per monnand

### DIFF
--- a/srv/apns.go
+++ b/srv/apns.go
@@ -809,7 +809,6 @@ func (self *apnsPushService) updateCheckPoint(prefix string) {
 
 func resultCollector(psp *PushServiceProvider, resChan chan<- *apnsResult, c net.Conn) {
 	defer c.Close()
-	defer close(resChan)
 	var bufData [6]byte
 	for {
 		var cmd uint8


### PR DESCRIPTION
@monnand 

"Channel resChan passed to function resultCollector() is actually self.resultChan, see line 448. Closing this channel will affect other goroutines reading from/writing to this channel since it is shared between goroutines. I checked the code again, I think the memory leak bug is actually caused by un-closed req.resChan. If I'm correct, then it means you will have lots of goroutines waiting in function waitResults() because the channel resChan passed to this function is never closed."

Revert "Merge pull request #60 from or-else/patch-1"

This reverts commit 3d726e38ccdb782e1aed2991cb09a595c5242898, reversing
changes made to 1948046c27947d1a48185019b58630d878cd51b1.