### PR TITLE
Drop GCM "InvalidRegistration" delivery points from database

### DIFF
--- a/push/errors.go
+++ b/push/errors.go
@@ -202,6 +202,24 @@ func NewUnsubscribeUpdate(psp *PushServiceProvider, dp *DeliveryPoint) error {
 
 /*********************/
 
+type InvalidRegistrationUpdate struct {
+	Provider    *PushServiceProvider
+	Destination *DeliveryPoint
+}
+
+func (e *InvalidRegistrationUpdate) Error() string {
+	return fmt.Sprintf("InvalidRegistration dropping %v", e.Destination.Name())
+}
+
+func NewInvalidRegistrationUpdate(psp *PushServiceProvider, dp *DeliveryPoint) error {
+	return &InvalidRegistrationUpdate{
+		Provider:    psp,
+		Destination: dp,
+	}
+}
+
+/*********************/
+
 type ConnectionError struct {
 	Err error
 }

--- a/pushbackend.go
+++ b/pushbackend.go
@@ -155,6 +155,23 @@ func (self *PushBackEnd) fixError(reqId string, event error, logger Logger, afte
 		} else {
 			logger.Infof("Service=%v Subscriber=%v DeliveryPoint=%v Update Success", service, sub, dp.Name())
 		}
+	case *InvalidRegistrationUpdate:
+		if err.Provider == nil || err.Destination == nil {
+			return nil
+		}
+		if service, ok = err.Provider.FixedData["service"]; !ok {
+			return nil
+		}
+		if sub, ok = err.Destination.FixedData["subscriber"]; !ok {
+			return nil
+		}
+		dp := err.Destination
+		e := self.Unsubscribe(service, sub, dp)
+		if e != nil {
+			logger.Errorf("Service=%v Subscriber=%v DeliveryPoint=%v Removing invalid reg failed: %v", service, sub, dp.Name(), e)
+		} else {
+			logger.Infof("Service=%v Subscriber=%v DeliveryPoint=%v Invalid registration removed", service, sub, dp.Name())
+		}
 	case *UnsubscribeUpdate:
 		if err.Provider == nil || err.Destination == nil {
 			return nil

--- a/srv/gcm.go
+++ b/srv/gcm.go
@@ -320,6 +320,12 @@ func (self *gcmPushService) multicast(psp *PushServiceProvider, dpList []*Delive
 				res.Content = notif
 				res.Destination = dp
 				resQueue <- res
+			case "InvalidRegistration":
+				res := new (PushResult)
+				res.Err = NewInvalidRegistrationUpdate(psp, dp)
+				res.Content = notif
+				res.Destination = dp
+				resQueue <- res
 			default:
 				res := new(PushResult)
 				res.Err = fmt.Errorf("GCMError: %v", errmsg)


### PR DESCRIPTION
@monnand There's nothing we can really do with an InvalidRegistration but drop it from the DB and log it. We had a bunch of these I believe from a botched batch import of device registrations