### PR TITLE
code.google.com/p/goconf no longer works. Use a github fork instead.

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -18,7 +18,7 @@
 package main
 
 import (
-	"code.google.com/p/goconf/conf"
+	"github.com/ifwe/goconf/conf"
 	. "github.com/uniqush/log"
 	. "github.com/uniqush/uniqush-push/db"
 	. "github.com/uniqush/uniqush-push/push"


### PR DESCRIPTION
As of January 25th, code.google.com no longer serves git.
- http://google-opensource.blogspot.com/2015/03/farewell-to-google-code.html

Created a mirror ifwe/goconf on github with no plans to modify it.
Feel free to export https://code.google.com/archive/p/goconf/ to the uniqush
project later.