### PR TITLE
Add more detail to the redis db errors; show how and where they happened

### DIFF
--- a/db/pushdb_test.go
+++ b/db/pushdb_test.go
@@ -20,7 +20,6 @@ package db
 import (
 	"fmt"
 	redis "github.com/monnand/goredis"
-	. "github.com/uniqush/uniqush-push/push"
 	"strconv"
 	"testing"
 )


### PR DESCRIPTION
Previously, if there were redis errors, they would not tell you what
operation caused the error (e.g. errors were similar to "Redis error:
Missing key").

Add details on context of the errors, both at the redis level and at the
db abstraction level.

Additionally, stop using `import .`, and use full module name instead
when using other modules.

This is discouraged: https://golang.org/doc/effective_go.html#package-names

> (Don't use the import . notation, which can simplify tests that must
> run outside the package they are testing, but should otherwise be
> avoided.)