### PR TITLE
Change the response format from logger output to a structured JSON response

### DIFF
--- a/main.go
+++ b/main.go
@@ -22,18 +22,19 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	. "github.com/uniqush/uniqush-push/srv"
+
+	"github.com/uniqush/uniqush-push/srv"
 )
 
 var uniqushPushConfFlags = flag.String("config", "/etc/uniqush/uniqush-push.conf", "Config file path")
 var uniqushPushShowVersionFlag = flag.Bool("version", false, "Version info")
 
-var uniqushPushVersion = "uniqush-push 1.5.2"
+var uniqushPushVersion = "uniqush-push 2.0.0"
 
-func installPushSrvices() {
-	InstallGCM()
-	InstallAPNS()
-	InstallADM()
+func installPushServices() {
+	srv.InstallGCM()
+	srv.InstallAPNS()
+	srv.InstallADM()
 }
 
 func main() {
@@ -43,7 +44,7 @@ func main() {
 		return
 	}
 	runtime.GOMAXPROCS(runtime.NumCPU() + 1)
-	installPushSrvices()
+	installPushServices()
 
 	err := Run(*uniqushPushConfFlags, uniqushPushVersion)
 	if err != nil {

--- a/restapi_pushresponse.go
+++ b/restapi_pushresponse.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"encoding/json"
+	"sync"
+	"time"
+
+	"github.com/uniqush/log"
+)
+
+type ApiPushResponseHandler struct {
+	response ApiPushResponse
+	logger   log.Logger
+	mutex    sync.Mutex
+}
+
+var _ ApiResponseHandler = (*ApiPushResponseHandler)(nil)
+
+type ApiPushResponse struct {
+	Type           string               `json:"type"`
+	Date           int64                `json:"date"`
+	SuccessCount   int                  `json:"successCount"`
+	FailureCount   int                  `json:"failureCount"`
+	DroppedCount   int                  `json:"droppedCount"`
+	SuccessDetails []ApiResponseDetails `json:"successDetails"`
+	FailureDetails []ApiResponseDetails `json:"failureDetails"`
+	DroppedDetails []ApiResponseDetails `json:"droppedDetails"`
+}
+
+func newPushResponseHandler(logger log.Logger) *ApiPushResponseHandler {
+	return &ApiPushResponseHandler{
+		response: newApiPushResponse(),
+		logger:   logger,
+	}
+}
+
+func newApiPushResponse() ApiPushResponse {
+	return ApiPushResponse{
+		Type:           "Push",
+		Date:           time.Now().Unix(),
+		SuccessDetails: make([]ApiResponseDetails, 0),
+		FailureDetails: make([]ApiResponseDetails, 0),
+		DroppedDetails: make([]ApiResponseDetails, 0),
+	}
+}
+
+func (self *ApiPushResponseHandler) AddDetailsToHandler(v ApiResponseDetails) {
+	self.mutex.Lock()
+	if v.Code == UNIQUSH_SUCCESS {
+		self.response.SuccessDetails = append(self.response.SuccessDetails, v)
+		self.response.SuccessCount += 1
+	} else if v.Code == UNIQUSH_UPDATE_UNSUBSCRIBE || v.Code == UNIQUSH_REMOVE_INVALID_REG {
+		self.response.DroppedDetails = append(self.response.DroppedDetails, v)
+		self.response.DroppedCount += 1
+	} else {
+		self.response.FailureDetails = append(self.response.FailureDetails, v)
+		self.response.FailureCount += 1
+	}
+	self.mutex.Unlock()
+}
+
+func (self *ApiPushResponseHandler) ToJSON() []byte {
+	json, err := json.Marshal(self.response)
+	if err != nil {
+		self.logger.Errorf("Failed to marshal json [%v] as string: %v", self.response, err)
+		return nil
+	}
+	return json
+}

--- a/restapi_response.go
+++ b/restapi_response.go
@@ -1,0 +1,56 @@
+package main
+
+const (
+	/* Not errors */
+	UNIQUSH_SUCCESS            = "UNIQUSH_SUCCESS"
+	UNIQUSH_REMOVE_INVALID_REG = "UNIQUSH_REMOVE_INVALID_REG"
+	UNIQUSH_UPDATE_UNSUBSCRIBE = "UNIQUSH_UPDATE_UNSUBSCRIBE"
+
+	/* Errors */
+	UNIQUSH_ERROR_GENERIC            = "UNIQUSH_ERROR_GENERIC"
+	UNIQUSH_ERROR_EMPTY_NOTIFICATION = "UNIQUSH_ERROR_EMPTY_NOTIFICATION"
+	UNIQUSH_ERROR_DATABASE           = "UNIQUSH_ERROR_DATABASE"
+	UNIQUSH_ERROR_FAILED_RETRY       = "UNIQUSH_ERROR_FAILED_RETRY"
+
+	UNIQUSH_ERROR_BUILD_PUSH_SERVICE_PROVIDER  = "UNIQUSH_ERROR_BUILD_PUSH_SERVICE_PROVIDER"
+	UNIQUSH_ERROR_UPDATE_PUSH_SERVICE_PROVIDER = "UNIQUSH_ERROR_UPDATE_PUSH_SERVICE_PROVIDER"
+
+	UNIQUSH_ERROR_BAD_DELIVERY_POINT    = "UNIQUSH_ERROR_BAD_DELIVERY_POINT"
+	UNIQUSH_ERROR_BUILD_DELIVERY_POINT  = "UNIQUSH_ERROR_BUILD_DELIVERY_POINT"
+	UNIQUSH_ERROR_UPDATE_DELIVERY_POINT = "UNIQUSH_ERROR_UPDATE_DELIVERY_POINT"
+
+	UNIQUSH_ERROR_CANNOT_GET_SERVICE    = "UNIQUSH_ERROR_CANNOT_GET_SERVICE"
+	UNIQUSH_ERROR_CANNOT_GET_SUBSCRIBER = "UNIQUSH_ERROR_CANNOT_GET_SUBSCRIBER"
+
+	UNIQUSH_ERROR_NO_DEVICE                = "UNIQUSH_ERROR_NO_DEVICE"
+	UNIQUSH_ERROR_NO_DELIVERY_POINT        = "UNIQUSH_ERROR_NO_DELIVERY_POINT"
+	UNIQUSH_ERROR_NO_PUSH_SERVICE_PROVIDER = "UNIQUSH_ERROR_NO_PUSH_SERVICE_PROVIDER"
+	UNIQUSH_ERROR_NO_SERVICE               = "UNIQUSH_ERROR_NO_SERVICE"
+	UNIQUSH_ERROR_NO_SUBSCRIBER            = "UNIQUSH_ERROR_NO_SUBSCRIBER"
+)
+
+type ApiResponseDetails struct {
+	RequestId           *string `json:"requestId"`
+	Service             *string `json:"service"`
+	From                *string `json:"from"`
+	Subscriber          *string `json:"subscriber"`
+	PushServiceProvider *string `json:"pushServiceProvider"`
+	DeliveryPoint       *string `json:"deliveryPoint"`
+	MessageId           *string `json:"messageId"`
+	Code                string  `json:"code"`
+}
+
+type ApiResponseHandler interface {
+	AddDetailsToHandler(v ApiResponseDetails)
+	ToJSON() []byte
+}
+
+type NullApiResponseHandler struct{}
+
+var _ ApiResponseHandler = (*NullApiResponseHandler)(nil)
+
+func (self *NullApiResponseHandler) AddDetailsToHandler(v ApiResponseDetails) {}
+
+func (self *NullApiResponseHandler) ToJSON() []byte {
+	return []byte{}
+}

--- a/restapi_simpleresponse.go
+++ b/restapi_simpleresponse.go
@@ -1,0 +1,60 @@
+package main
+
+import (
+	"encoding/json"
+	"github.com/uniqush/log"
+	"time"
+)
+
+const (
+	STATUS_SUCCESS = iota
+	STATUS_FAILURE
+	STATUS_UNKNOWN
+)
+
+type ApiSimpleResponseHandler struct {
+	response ApiSimpleResponse
+	logger   log.Logger
+}
+
+var _ ApiResponseHandler = (*ApiSimpleResponseHandler)(nil)
+
+type ApiSimpleResponse struct {
+	Type    string             `json:"type"`
+	Date    int64              `json:"date"`
+	Status  int                `json:"status"`
+	Details ApiResponseDetails `json:"details"`
+}
+
+func newSimpleResponseHandler(logger log.Logger, apiType string) *ApiSimpleResponseHandler {
+	return &ApiSimpleResponseHandler{
+		response: newApiSimpleResponse(apiType),
+		logger:   logger,
+	}
+}
+
+func newApiSimpleResponse(apiType string) ApiSimpleResponse {
+	return ApiSimpleResponse{
+		Type:   apiType,
+		Date:   time.Now().Unix(),
+		Status: STATUS_UNKNOWN,
+	}
+}
+
+func (self *ApiSimpleResponseHandler) AddDetailsToHandler(v ApiResponseDetails) {
+	if v.Code == UNIQUSH_SUCCESS {
+		self.response.Status = STATUS_SUCCESS
+	} else {
+		self.response.Status = STATUS_FAILURE
+	}
+	self.response.Details = v
+}
+
+func (self *ApiSimpleResponseHandler) ToJSON() []byte {
+	json, err := json.Marshal(self.response)
+	if err != nil {
+		self.logger.Errorf("Failed to marshal json [%v] as string: %v", self.response, err)
+		return nil
+	}
+	return json
+}

--- a/srv/apns-test/apns-test.sh
+++ b/srv/apns-test/apns-test.sh
@@ -7,7 +7,10 @@
 PWD=`pwd`
 
 curl http://127.0.0.1:9898/addpsp -d service=myservice -d pushservicetype=apns -d cert=$PWD/localhost.cert -d key=$PWD/localhost.key -d addr=127.0.0.1:8080 -d skipverify=true
+echo
 
 curl http://127.0.0.1:9898/subscribe -d service=myservice -d subscriber=uniqush.client -d pushservicetype=apns -d devtoken=3df3e210e7adf35f840f45b269b760d9d51081569dc4509ee98bb4d4c92a828e
+echo
 
 curl http://127.0.0.1:9898/push -d service=myservice -d subscriber=uniqush.client -d msg="Hello World"
+echo


### PR DESCRIPTION
By using a JSON response format, this allows uniqush clients to know if the API was successful.
API clients will be able to easily determine the reason an API failed, without resorting to heuristics (checking if the response contains a certain string).
Additionally, it is much easier for clients to process the outcome of a push, when a push involves more than one device.

- bump version from 1.5.x to 1.6.0, since the API response format changed. No change in functionality or api request format. **(or should this be a major version change, instead?)**

(This is mostly the same as what we use internally. 
The original author's commits were edited to remove a field that wasn't used by upstream. 
Additionally, `go fmt` was run on every commit, and some commits were squashed)

Barely related to issue #55 (Related in the sense that the responses are much easier to parse)

Also fixes #71 

### Examples

Example return value of `/subscribe` (after indenting), with fake data

```json
{
  "errorMsg": null,
  "code": "UNIQUSH_SUCCESS",
  "requestId": null,
  "service": "fooserv",
  "from": "a.b.c.d:39317",
  "subscriber": "foo.1234",
  "pushServiceProvider": "apns:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
  "deliveryPoint": "apns:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
  "messageId": null
}
```

Example return value of `/push`

```json
{
  "droppedDetails": [],
  "failureDetails": [],
  "successDetails": [
    {
      "code": "UNIQUSH_SUCCESS",
      "requestId": "56c3cb5f-RnIk4aFK4c7xKjcwtt143Q==",
      "service": "fooserv",
      "from": "a.b.c.d:37360",
      "subscriber": "foo.1234",
      "pushServiceProvider": "apns:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
      "deliveryPoint": "apns:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
      "messageId": "apns:apns:cccccccccccccccccccccccccccccccccccccccc-78"
    }
  ],
  "droppedCount": 0,
  "failureCount": 0,
  "successCount": 1,
  "date": 1455672159,
  "type": "Push"
}
```

Example return value of `/addpsp`:

```json
{
  "details": {
    "code": "UNIQUSH_SUCCESS",
    "messageId": null,
    "deliveryPoint": null,
    "pushServiceProvider": "apns:8fa8483afc5f4461117c8c2d61b36e7b6c8d3eb2",
    "subscriber": null,
    "from": "127.0.0.1:42532",
    "service": "myservice",
    "requestId": null
  },
  "status": 0,
  "date": 1455672625,
  "type": "AddPushServiceProvider"
}
```

EDIT: the comment about including errorMsg was outdated - this wasn't part of the original commit. It was added later, as part of a larger change.