### PR TITLE
 Include errorMsg in uniqush responses; create common interface PushError

### DIFF
--- a/push/pushservicemngr.go
+++ b/push/pushservicemngr.go
@@ -30,7 +30,7 @@ type serviceType struct {
 
 type PushServiceManager struct {
 	serviceTypes map[string]*serviceType
-	errChan      chan<- error
+	errChan      chan<- PushError
 }
 
 var (
@@ -192,14 +192,14 @@ func (m *PushServiceManager) Push(psp *PushServiceProvider, dpQueue <-chan *Deli
 		r.Destination = nil
 		r.MsgId = ""
 		r.Content = notif
-		r.Err = fmt.Errorf("InvalidPushServiceProvider")
+		r.Err = NewError("InvalidPushServiceProvider")
 		resQueue <- r
 	}
 
 	wg.Wait()
 }
 
-func (m *PushServiceManager) SetErrorReportChan(errChan chan<- error) {
+func (m *PushServiceManager) SetErrorReportChan(errChan chan<- PushError) {
 	m.errChan = errChan
 	for _, t := range m.serviceTypes {
 		t.pst.SetErrorReportChan(errChan)

--- a/push/pushservicetype.go
+++ b/push/pushservicetype.go
@@ -24,7 +24,7 @@ type PushResult struct {
 	Destination *DeliveryPoint
 	Content     *Notification
 	MsgId       string
-	Err         error
+	Err         PushError
 }
 
 func (r *PushResult) IsError() bool {
@@ -72,7 +72,8 @@ type PushServiceType interface {
 
 	// Set a channel for the push service provider so that it can report error even if
 	// there is no method call on it.
-	SetErrorReportChan(errChan chan<- error)
+	// The type of the errors sent may cause the push service manager to take various actions.
+	SetErrorReportChan(errChan chan<- PushError)
 
 	Finalize()
 }

--- a/restapi.go
+++ b/restapi.go
@@ -151,12 +151,12 @@ func (self *RestAPI) changePushServiceProvider(kv map[string]string, logger log.
 	psp, err := self.psm.BuildPushServiceProviderFromMap(kv)
 	if err != nil {
 		logger.Errorf("From=%v Cannot build push service provider: %v", remoteAddr, err)
-		return ApiResponseDetails{From: &remoteAddr, Code: UNIQUSH_ERROR_BUILD_PUSH_SERVICE_PROVIDER}
+		return ApiResponseDetails{From: &remoteAddr, Code: UNIQUSH_ERROR_BUILD_PUSH_SERVICE_PROVIDER, ErrorMsg: strPtrOfErr(err)}
 	}
 	service, err := getServiceFromMap(kv, true)
 	if err != nil {
 		logger.Errorf("From=%v Cannot get service name: %v; %v", remoteAddr, service, err)
-		return ApiResponseDetails{From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SERVICE}
+		return ApiResponseDetails{From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SERVICE, ErrorMsg: strPtrOfErr(err)}
 	}
 	if add {
 		err = self.backend.AddPushServiceProvider(service, psp)
@@ -165,7 +165,7 @@ func (self *RestAPI) changePushServiceProvider(kv map[string]string, logger log.
 	}
 	if err != nil {
 		logger.Errorf("From=%v Failed: %v", remoteAddr, err)
-		return ApiResponseDetails{From: &remoteAddr, Code: UNIQUSH_ERROR_GENERIC}
+		return ApiResponseDetails{From: &remoteAddr, Code: UNIQUSH_ERROR_GENERIC, ErrorMsg: strPtrOfErr(err)}
 	}
 	pspName := psp.Name()
 	logger.Infof("From=%v Service=%v PushServiceProvider=%v Success!", remoteAddr, service, pspName)
@@ -176,17 +176,17 @@ func (self *RestAPI) changeSubscription(kv map[string]string, logger log.Logger,
 	dp, err := self.psm.BuildDeliveryPointFromMap(kv)
 	if err != nil {
 		logger.Errorf("Cannot build delivery point: %v", err)
-		return ApiResponseDetails{From: &remoteAddr, Code: UNIQUSH_ERROR_BUILD_DELIVERY_POINT}
+		return ApiResponseDetails{From: &remoteAddr, Code: UNIQUSH_ERROR_BUILD_DELIVERY_POINT, ErrorMsg: strPtrOfErr(err)}
 	}
 	service, err := getServiceFromMap(kv, true)
 	if err != nil {
 		logger.Errorf("From=%v Cannot get service name: %v; %v", remoteAddr, service, err)
-		return ApiResponseDetails{From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SERVICE}
+		return ApiResponseDetails{From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SERVICE, ErrorMsg: strPtrOfErr(err)}
 	}
 	subs, err := getSubscribersFromMap(kv, true)
 	if err != nil {
 		logger.Errorf("From=%v Service=%v Cannot get subscriber: %v", remoteAddr, service, err)
-		return ApiResponseDetails{From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SUBSCRIBER}
+		return ApiResponseDetails{From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SUBSCRIBER, ErrorMsg: strPtrOfErr(err)}
 	}
 
 	var psp *PushServiceProvider
@@ -197,7 +197,7 @@ func (self *RestAPI) changeSubscription(kv map[string]string, logger log.Logger,
 	}
 	if err != nil {
 		logger.Errorf("From=%v Failed: %v", remoteAddr, err)
-		return ApiResponseDetails{From: &remoteAddr, Code: UNIQUSH_ERROR_GENERIC}
+		return ApiResponseDetails{From: &remoteAddr, Code: UNIQUSH_ERROR_GENERIC, ErrorMsg: strPtrOfErr(err)}
 	}
 	dpName := dp.Name()
 	if psp == nil {

--- a/restapi_response.go
+++ b/restapi_response.go
@@ -38,10 +38,13 @@ type ApiResponseDetails struct {
 	DeliveryPoint       *string `json:"deliveryPoint"`
 	MessageId           *string `json:"messageId"`
 	Code                string  `json:"code"`
-	ErrorMsg            *string `json:"errorMsg"`
+	ErrorMsg            *string `json:"errorMsg,omitempty"`
 }
 
 func strPtrOfErr(e error) *string {
+	if e == nil {
+		return nil
+	}
 	s := e.Error()
 	return &s
 }

--- a/restapi_response.go
+++ b/restapi_response.go
@@ -38,6 +38,12 @@ type ApiResponseDetails struct {
 	DeliveryPoint       *string `json:"deliveryPoint"`
 	MessageId           *string `json:"messageId"`
 	Code                string  `json:"code"`
+	ErrorMsg            *string `json:"errorMsg"`
+}
+
+func strPtrOfErr(e error) *string {
+	s := e.Error()
+	return &s
 }
 
 type ApiResponseHandler interface {

--- a/srv/gcm.go
+++ b/srv/gcm.go
@@ -174,7 +174,7 @@ func (self *gcmPushService) multicast(psp *PushServiceProvider, dpList []*Delive
 			res.Provider = psp
 			res.Content = notif
 
-			res.Err = e0
+			res.Err = NewErrorf("Error converting payload to JSON: %v", e0)
 			res.Destination = dp
 			resQueue <- res
 		}
@@ -188,7 +188,7 @@ func (self *gcmPushService) multicast(psp *PushServiceProvider, dpList []*Delive
 			res.Provider = psp
 			res.Content = notif
 
-			res.Err = e1
+			res.Err = NewErrorf("Error constructing HTTP request: %v", e1)
 			res.Destination = dp
 			resQueue <- res
 		}
@@ -225,7 +225,7 @@ func (self *gcmPushService) multicast(psp *PushServiceProvider, dpList []*Delive
 				res.Err = NewRetryErrorWithReason(psp, dp, notif, after, err)
 
 			} else {
-				res.Err = e2
+				res.Err = NewErrorf("Unrecoverable HTTP error sending to GCM: %v", e2)
 			}
 			resQueue <- res
 		}
@@ -281,7 +281,7 @@ func (self *gcmPushService) multicast(psp *PushServiceProvider, dpList []*Delive
 		res := new(PushResult)
 		res.Provider = psp
 		res.Content = notif
-		res.Err = err
+		res.Err = NewErrorf("Failed to read GCM response: %v", err)
 		resQueue <- res
 		return
 	}
@@ -293,7 +293,7 @@ func (self *gcmPushService) multicast(psp *PushServiceProvider, dpList []*Delive
 		res := new(PushResult)
 		res.Provider = psp
 		res.Content = notif
-		res.Err = err
+		res.Err = NewErrorf("Failed to decode GCM response: %v", err)
 		resQueue <- res
 		return
 	}
@@ -328,7 +328,7 @@ func (self *gcmPushService) multicast(psp *PushServiceProvider, dpList []*Delive
 				resQueue <- res
 			default:
 				res := new(PushResult)
-				res.Err = fmt.Errorf("GCMError: %v", errmsg)
+				res.Err = NewErrorf("GCMError: %v", errmsg)
 				res.Provider = psp
 				res.Content = notif
 				res.Destination = dp
@@ -397,6 +397,6 @@ func (self *gcmPushService) Push(psp *PushServiceProvider, dpQueue <-chan *Deliv
 	close(resQueue)
 }
 
-func (self *gcmPushService) SetErrorReportChan(errChan chan<- error) {
+func (self *gcmPushService) SetErrorReportChan(errChan chan<- PushError) {
 	return
 }


### PR DESCRIPTION
Include errorMsg in uniqush responses; create common interface PushError

errorMsg in API responses makes it slightly easier to debug problems in the clients of uniqush
without referring to log files.

Also, add additional context for some errors, etc.

Add a specific interface indicating which errors will be passed to the push backend.
Modules now use `PushError` for public APIs, and other `error` subtypes,
such as `net.Error`, `error`, etc., for implementation detail.

- This makes it easier to refactor code. If you know something isn't a
  `PushError`, it's clearer that it may need to be handled specially.
  (E.g. a `net.Error` may influence the retry behavior of the APNS module.
   Where you see `err PushError`, you know it definitely isn't a `net.Error`)
- Add `ErrorReport`, which does the same thing a generic `error` used to do.
