### PR TITLE
Fix json encoding of apns payloads - remove unsupported \u notation.

### DIFF
--- a/srv/apns.go
+++ b/srv/apns.go
@@ -22,7 +22,6 @@ import (
 	"crypto/tls"
 	"encoding/binary"
 	"encoding/hex"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -37,6 +36,7 @@ import (
 	"github.com/uniqush/cache"
 	"github.com/uniqush/connpool"
 	"github.com/uniqush/uniqush-push/push"
+	"github.com/uniqush/uniqush-push/srv/apns/common"
 )
 
 const (
@@ -796,7 +796,7 @@ func toAPNSPayload(n *push.Notification) ([]byte, push.PushError) {
 
 	aps["alert"] = alert
 	payload["aps"] = aps
-	j, err := json.Marshal(payload)
+	j, err := common.MarshalJSONUnescaped(payload)
 	if err != nil {
 		return nil, push.NewErrorf("Failed to convert notification data to JSON: %v", err)
 	}

--- a/srv/apns/common/json.go
+++ b/srv/apns/common/json.go
@@ -1,0 +1,63 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// extractToken takes the remainder of a JSON-encoded string. It removes a token, converting html escaped tokens to the equivalent non-escaped token.
+func extractToken(s string) (remainder string, token string) {
+	// convert instances of \u00xy to a single character.
+	n := len(s)
+	if n < 6 {
+		return "", s
+	}
+	if s[0] != '\\' {
+		return s[1:], s[0:1]
+	}
+	// two backslashes, `\t`, etc. should be a single token. Don't care about "\\x.."
+	if s[1] != 'u' {
+		return s[2:], s[0:2]
+	}
+
+	// s begins with the 4 bytes `\u00`, the remainder is a unicode escape code.
+	remainder = s[6:]
+	if s[2] == '0' && s[3] == '0' {
+		switch s[4:6] {
+		case "22":
+			token = "\\\""
+		case "26":
+			token = "&"
+		case "3c":
+			token = "<"
+		case "3e":
+			token = ">"
+		default:
+			token = s[:6]
+		}
+	} else {
+		token = s[:6]
+	}
+	return remainder, token
+}
+
+// MarshalJSONUnescaped undoes the HTML escaping done by encoding/json.
+func MarshalJSONUnescaped(v interface{}) ([]byte, error) {
+	// Get the HTML escaped
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	s := string(b)
+	if !strings.Contains(s, "\\u00") {
+		return b, nil
+	}
+	buf := &bytes.Buffer{}
+	for len(s) > 0 {
+		var token string
+		s, token = extractToken(s)
+		buf.WriteString(token)
+	}
+	return buf.Bytes(), nil
+}

--- a/srv/apns/common/json_test.go
+++ b/srv/apns/common/json_test.go
@@ -1,0 +1,35 @@
+package common
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestMarshalJSONUnescaped tests that HTML encoding is properly removed from json.Marshal, so that APNS receives a payload it supports.
+func TestMarshalJSONUnescaped(t *testing.T) {
+	testValues := []string{
+		`null`,              // Null
+		`{"a":"\\u003c"}`,   // Double backslashes, not an escape sequence in json
+		`{"a":"\\\\u003c"}`, // Quadruple backslashes, not an escape sequence in json
+		`{"a":"\u0019"}`,    // An ASCII control code. Keep it escaped.
+		`{"<a":"<&>"}`,
+		`"<&>\""`,
+		`{"a":">\""}`, // A quotation mark. Should use backslashes to escape instead of unicode escape sequence
+		`{"a":"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\t\n\u000b\u000c\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*+,-.\\/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{|}~"}`,
+		`{"a":"한국어/조선말"}`, // unicode should continue to work.
+	}
+
+	for _, testValue := range testValues {
+		var data interface{}
+		originalBytes := []byte(testValue)
+		err := json.Unmarshal(originalBytes, &data)
+		if err != nil {
+			t.Fatalf("Invalid test value %q: %v", testValue, err)
+		}
+		reencoded, err := MarshalJSONUnescaped(data)
+		if !bytes.Equal(reencoded, originalBytes) {
+			t.Errorf("Expected %v(%s), got %v(%s)", originalBytes, testValue, reencoded, string(reencoded))
+		}
+	}
+}


### PR DESCRIPTION
(Where reasonable)

According to apple support (Can be seen if you attempt to send a notification)

> "APNs does not support the JSON \U notation; just put the UTF-8 character in
> the alert directly, such as ∃ instead of \U2203."

International characters are already unescaped. However, uniqush should
manually unescape '<', '>', '&', and '"', in case they occur in a push
notification payload.
(The push notification message would render '"' as "\u0022" otherwise)
Continuing to escape the subset of obscure ascii escape codes from 0-31.
(In a later PR, may want to test passing them along in a format that apps can decode)

See issue 8592 from https://github.com/golang/go/issues/ : "encoding/json: No way to avoid HTMLEscape when Marshal()-ing"

