### PR TITLE
Fix stack overflow in errors.go

### DIFF
--- a/push/errors.go
+++ b/push/errors.go
@@ -276,7 +276,7 @@ type ConnectionError struct {
 }
 
 func (e *ConnectionError) Error() string {
-	return fmt.Sprintf("ConnectionError %v", e)
+	return fmt.Sprintf("ConnectionError %v", e.Err)
 }
 
 func NewConnectionError(err error) *ConnectionError {


### PR DESCRIPTION
in Error(), fmt.Sprintf was calling Error(), of the same object.
fmt.Sprintf should be passed the member err.Err instead.

Fix bug introduced in b11f9a19 or earlier