### PR TITLE
Commit /subscriptions, /services and /rebuildserviceset API endpoints

### DIFF
--- a/conf/uniqush-push.conf
+++ b/conf/uniqush-push.conf
@@ -13,6 +13,10 @@ loglevel=standard
 log=on
 loglevel=standard
 
+[PSPs]
+log=on
+loglevel=standard
+
 [Subscribe]
 log=on
 loglevel=standard
@@ -22,6 +26,14 @@ log=on
 loglevel=standard
 
 [Push]
+log=on
+loglevel=standard
+
+[Subscriptions]
+log=on
+loglevel=standard
+
+[Services]
 log=on
 loglevel=standard
 

--- a/configparser.go
+++ b/configparser.go
@@ -32,9 +32,12 @@ const (
 	LOGGER_WEB = iota
 	LOGGER_ADDPSP
 	LOGGER_RMPSP
+	LOGGER_PSPS
 	LOGGER_SUB
 	LOGGER_UNSUB
 	LOGGER_PUSH
+	LOGGER_SUBSCRIPTIONS
+	LOGGER_SERVICES
 	LOGGER_NR_LOGGERS
 )
 
@@ -165,6 +168,12 @@ func LoadLoggers(c *conf.ConfigFile) (loggers []log.Logger, err error) {
 		return
 	}
 
+	loggers[LOGGER_PSPS], err = loadLogger(logfile, c, "PSPs", "[PSPs]")
+	if err != nil {
+		loggers = nil
+		return
+	}
+
 	loggers[LOGGER_SUB], err = loadLogger(logfile, c, "Subscribe", "[Subscribe]")
 	if err != nil {
 		loggers = nil
@@ -178,6 +187,17 @@ func LoadLoggers(c *conf.ConfigFile) (loggers []log.Logger, err error) {
 	}
 
 	loggers[LOGGER_PUSH], err = loadLogger(logfile, c, "Push", "[Push]")
+	if err != nil {
+		loggers = nil
+		return
+	}
+
+	loggers[LOGGER_SUBSCRIPTIONS], err = loadLogger(logfile, c, "Subscriptions", "[Subscriptions]")
+	if err != nil {
+		loggers = nil
+		return
+	}
+	loggers[LOGGER_SERVICES], err = loadLogger(logfile, c, "Services", "[Services]")
 	if err != nil {
 		loggers = nil
 		return

--- a/db/rawdb.go
+++ b/db/rawdb.go
@@ -18,6 +18,7 @@
 package db
 
 import (
+	"github.com/uniqush/log"
 	"github.com/uniqush/uniqush-push/push"
 )
 
@@ -50,6 +51,7 @@ type pushRawDatabaseWriter interface {
 	SetPushServiceProvider(psp *push.PushServiceProvider) error
 	RemoveDeliveryPoint(dp string) error
 	RemovePushServiceProvider(psp string) error
+	RebuildServiceSet() error
 
 	AddDeliveryPointToServiceSubscriber(srv, sub, dp string) error
 	RemoveDeliveryPointFromServiceSubscriber(srv, sub, dp string) error
@@ -66,6 +68,9 @@ type pushRawDatabaseWriter interface {
 type pushRawDatabaseReader interface {
 	GetDeliveryPoint(name string) (*push.DeliveryPoint, error)
 	GetPushServiceProvider(name string) (*push.PushServiceProvider, error)
+	GetServiceNames() ([]string, error)
+	GetPushServiceProviderConfigs([]string) ([]*push.PushServiceProvider, []error)
+	GetSubscriptions(queryServices []string, subscriber string, logger log.Logger) ([]map[string]string, error)
 
 	GetDeliveryPointsNameByServiceSubscriber(srv, sub string) (map[string][]string, error)
 	GetPushServiceProviderNameByServiceDeliveryPoint(srv, dp string) (string, error)

--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 var uniqushPushConfFlags = flag.String("config", "/etc/uniqush/uniqush-push.conf", "Config file path")
 var uniqushPushShowVersionFlag = flag.Bool("version", false, "Version info")
 
-var uniqushPushVersion = "uniqush-push 2.0.0"
+var uniqushPushVersion = "uniqush-push 2.1.0"
 
 func installPushServices() {
 	srv.InstallGCM()

--- a/srv/apns/apns-test/apns-test.sh
+++ b/srv/apns/apns-test/apns-test.sh
@@ -12,5 +12,11 @@ echo
 curl http://127.0.0.1:9898/subscribe -d service=myservice -d subscriber=uniqush.client -d pushservicetype=apns -d devtoken=3df3e210e7adf35f840f45b269b760d9d51081569dc4509ee98bb4d4c92a828e
 echo
 
+# Test subscriptions, with and without a list of services.
+curl http://127.0.0.1:9898/subscriptions -d subscriber=uniqush.client -d service=myservice
+curl http://127.0.0.1:9898/rebuildserviceset; echo
+curl http://127.0.0.1:9898/subscriptions -d subscriber=uniqush.client
+curl http://127.0.0.1:9898/psps
+
 curl http://127.0.0.1:9898/push -d service=myservice -d subscriber=uniqush.client -d msg="Hello World"
 echo


### PR DESCRIPTION
/subscriptions shows the subscription details (tokens/regids, push
service type, service names) of a given subscriber. If no service is
provided in the query, all services are queried.

As part of this change, the set of all service names must be tracked in
redis. KEYS would be too slow to use, so a new set SERVICES.{0} was added.

- If the redis databases sharded, then the {0} could be used as a shard scheme,
  to avoid hitting multiple databases for what would be a small set.
- /rebuildserviceset is added, to be manually run to create the service
  set for pre-existing uniqush users. This hasn't been fully tested yet.

For convenience, /psps was also added.
- The API response maps service names to a list of psps with that service name.
  (From the documentation, I'm not sure if it is meant to be possible
   for a service name to be shareable among 2 or more PSPs, e.g. with
   different push service types.)

