### PR TITLE
Omit empty values from the JSON being returned from the REST API

### DIFF
--- a/restapi_response.go
+++ b/restapi_response.go
@@ -30,13 +30,13 @@ const (
 )
 
 type ApiResponseDetails struct {
-	RequestId           *string `json:"requestId"`
-	Service             *string `json:"service"`
-	From                *string `json:"from"`
-	Subscriber          *string `json:"subscriber"`
-	PushServiceProvider *string `json:"pushServiceProvider"`
-	DeliveryPoint       *string `json:"deliveryPoint"`
-	MessageId           *string `json:"messageId"`
+	RequestId           *string `json:"requestId,omitempty"`
+	Service             *string `json:"service,omitempty"`
+	From                *string `json:"from,omitempty"`
+	Subscriber          *string `json:"subscriber,omitempty"`
+	PushServiceProvider *string `json:"pushServiceProvider,omitempty"`
+	DeliveryPoint       *string `json:"deliveryPoint,omitempty"`
+	MessageId           *string `json:"messageId,omitempty"`
 	Code                string  `json:"code"`
 	ErrorMsg            *string `json:"errorMsg,omitempty"`
 }


### PR DESCRIPTION
If they weren't set/were empty, they don't need to be returned

- e.g. ErrorMsg isn't useful on success
- e.g. PushServiceProvider may not be applicable, a push error may be caused by the request data instead