### PR TITLE
Use sync.Once as singleton implimentation

### DIFF
--- a/push/pushservicemngr.go
+++ b/push/pushservicemngr.go
@@ -38,16 +38,11 @@ var (
 )
 
 /* This is a singleton */
-func newPushServiceManager() *PushServiceManager {
-	ret := new(PushServiceManager)
-	ret.serviceTypes = make(map[string]*serviceType, 5)
-	return ret
-}
-
 func GetPushServiceManager() *PushServiceManager {
-	if pushServiceManager == nil {
-		pushServiceManager = newPushServiceManager()
-	}
+	once.Do(func() {
+		pushServiceManager = new(PushServiceManager)
+		pushServiceManager.serviceTypes = make(map[string]*serviceType, 5)
+	})
 	return pushServiceManager
 }
 

--- a/push/pushservicemngr.go
+++ b/push/pushservicemngr.go
@@ -35,6 +35,7 @@ type PushServiceManager struct {
 
 var (
 	pushServiceManager *PushServiceManager
+	once               sync.Once
 )
 
 /* This is a singleton */


### PR DESCRIPTION
To make singleton creation a more secure one using sync.Once.