### PR TITLE
Allow passing raw payloads to the APNS, GCM, and ADM modules

### DIFF
--- a/srv/adm.go
+++ b/srv/adm.go
@@ -90,7 +90,7 @@ func (self *admPushService) BuildPushServiceProviderFromMap(kv map[string]string
 	if clientsecret, ok := kv["clientsecret"]; ok && len(clientsecret) > 0 {
 		psp.FixedData["clientsecret"] = clientsecret
 	} else {
-		return errors.New("NoClientSecrete")
+		return errors.New("NoClientSecret")
 	}
 
 	return nil
@@ -181,7 +181,7 @@ func requestToken(psp *push.PushServiceProvider) push.PushError {
 		return push.NewBadPushServiceProviderWithDetails(psp, "NoClientID")
 	}
 	if cserect, ok = psp.FixedData["clientsecret"]; !ok {
-		return push.NewBadPushServiceProviderWithDetails(psp, "NoClientSecrete")
+		return push.NewBadPushServiceProviderWithDetails(psp, "NoClientSecret")
 	}
 	form := url.Values{}
 	form.Set("grant_type", "client_credentials")

--- a/srv/adm_test.go
+++ b/srv/adm_test.go
@@ -1,0 +1,57 @@
+package srv
+
+import (
+	"encoding/json"
+	"testing"
+)
+import (
+	"github.com/uniqush/uniqush-push/push"
+)
+
+func testADMNotifToMessage(t *testing.T, postData map[string]string, expectedPayload string) {
+	notif := push.NewEmptyNotification()
+	notif.Data = postData
+	msg, err := notifToMessage(notif)
+	if err != nil {
+		t.Fatalf("Encountered error %v\n", err)
+	}
+	payload, jsonErr := json.Marshal(msg)
+	if jsonErr != nil {
+		t.Fatalf("Encountered error decoding json: %v\n", err)
+	}
+	if string(payload) != expectedPayload {
+		t.Errorf("Expected %s, got %s", expectedPayload, string(payload))
+	}
+}
+
+func TestADMNotifToMessageWithRawPayload(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":            "somegroup",
+		"uniqush.payload.adm": `{"baz":"bat","foo":"bar"}`,
+		"ignoredParam":        "foo",
+	}
+	expectedPayload := `{"data":{"baz":"bat","foo":"bar"},"consolidationKey":"somegroup"}`
+	testADMNotifToMessage(t, postData, expectedPayload)
+}
+
+func TestADMNotifToMessageWithRawPayloadAndTTL(t *testing.T) {
+	postData := map[string]string{
+		"uniqush.payload.adm": `{"foo":"bar"}`,
+		"ttl": "100",
+	}
+	expectedPayload := `{"data":{"foo":"bar"},"expiresAfter":100}`
+	testADMNotifToMessage(t, postData, expectedPayload)
+}
+
+func TestADMNotifToMessageWithTTL(t *testing.T) {
+	postData := map[string]string{
+		"other":     "value",
+		"other.foo": "bar",
+		"ttl":       "5",
+		// ADM module should ignore anything it doesn't recognize begining with "uniqush.", those are reserved.
+		"uniqush.payload.apns": "{}",
+		"uniqush.payload.gcm":  `{"key":{},"x":"y"}`,
+	}
+	expectedPayload := `{"data":{"other":"value","other.foo":"bar"},"expiresAfter":5}`
+	testADMNotifToMessage(t, postData, expectedPayload)
+}

--- a/srv/adm_test.go
+++ b/srv/adm_test.go
@@ -17,7 +17,7 @@ func testADMNotifToMessage(t *testing.T, postData map[string]string, expectedPay
 	}
 	payload, jsonErr := json.Marshal(msg)
 	if jsonErr != nil {
-		t.Fatalf("Encountered error decoding json: %v\n", err)
+		t.Fatalf("Encountered error decoding json: %v\n", jsonErr)
 	}
 	if string(payload) != expectedPayload {
 		t.Errorf("Expected %s, got %s", expectedPayload, string(payload))

--- a/srv/apns/payload.go
+++ b/srv/apns/payload.go
@@ -19,13 +19,50 @@ package apns
 // Contains functions for building a payload from the url parameter abstraction.
 
 import (
+	"encoding/json"
+	"fmt"
 	"strconv"
+	"strings"
 
 	"github.com/uniqush/uniqush-push/push"
 	"github.com/uniqush/uniqush-push/srv/apns/common"
 )
 
+// validateRawAPNSPayload tests that the client-provided JSON payload can be sent to APNS.
+// It converts it to bytes if it is, otherwise it returns a push.PushError.
+func validateRawAPNSPayload(payload string) ([]byte, push.PushError) {
+	// https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/ApplePushService.html#//apple_ref/doc/uid/TP40008194-CH100-SW1
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(payload), &data)
+	if data == nil {
+		return nil, push.NewBadNotificationWithDetails(fmt.Sprintf("Could not parse payload: %v", err))
+	}
+	aps, ok := data["aps"]
+	if !ok {
+		return nil, push.NewBadNotificationWithDetails("Payload missing aps")
+	}
+	aps_dict, ok := aps.(map[string]interface{})
+	if !ok {
+		return nil, push.NewBadNotificationWithDetails("aps is not a dictionary")
+	}
+	if _, ok := aps_dict["alert"]; !ok {
+		if content_available, ok := aps_dict["content-available"]; !ok || content_available != "1" {
+			return nil, push.NewBadNotificationWithDetails("Missing alert and this is not a silent notification(content-available is not 1)")
+		}
+	}
+
+	// TODO: Could optionally validate provided fields further according to documentation of the "The Notification Payload" section.
+	// Creating a custom struct would make it simpler.
+	// (E.g. body, action-loc-key, loc-key, loc-args, badge, sound, content-available, launch-image)
+	return []byte(payload), nil
+}
+
 func toAPNSPayload(n *push.Notification) ([]byte, push.PushError) {
+	// If "uniqush.payload.apns" is provided, then that will be used instead of the other POST parameters.
+	if payloadJSON, ok := n.Data["uniqush.payload.apns"]; ok {
+		bytes, err := validateRawAPNSPayload(payloadJSON)
+		return bytes, err
+	}
 	payload := make(map[string]interface{})
 	aps := make(map[string]interface{})
 	alert := make(map[string]interface{})
@@ -39,17 +76,15 @@ func toAPNSPayload(n *push.Notification) ([]byte, push.PushError) {
 			alert[k] = v
 		case "loc-args":
 			alert[k] = parseList(v)
-		case "badge":
+		case "badge", "content-available":
 			b, err := strconv.Atoi(v)
 			if err != nil {
 				continue
 			} else {
-				aps["badge"] = b
+				aps[k] = b
 			}
 		case "sound":
 			aps["sound"] = v
-		case "content-available":
-			aps["content-available"] = v
 		case "img":
 			alert["launch-image"] = v
 		case "id":
@@ -59,6 +94,9 @@ func toAPNSPayload(n *push.Notification) ([]byte, push.PushError) {
 		case "ttl":
 			continue
 		default:
+			if strings.HasPrefix(k, "uniqush.") { // keys beginning with "uniqush." are reserved by uniqush.
+				continue
+			}
 			payload[k] = v
 		}
 	}

--- a/srv/gcm_test.go
+++ b/srv/gcm_test.go
@@ -1,0 +1,68 @@
+package srv
+
+import (
+	"testing"
+)
+import (
+	"github.com/uniqush/uniqush-push/push"
+)
+
+func testToGCMPayload(t *testing.T, postData map[string]string, regIds []string, expectedPayload string) {
+	notif := push.NewEmptyNotification()
+	notif.Data = postData
+	payload, err := toGCMPayload(notif, regIds)
+	if err != nil {
+		t.Fatalf("Encountered error %v\n", err)
+	}
+	if string(payload) != expectedPayload {
+		t.Errorf("Expected %s, got %s", expectedPayload, string(payload))
+	}
+}
+
+func TestToGCMPayloadWithRawPayload(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":            "somegroup",
+		"uniqush.payload.gcm": `{"message":{"key": {},"x":"y"},"other":{}}`,
+		"foo": "bar",
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"message":{"key":{},"x":"y"},"other":{}},"time_to_live":3600}`
+	testToGCMPayload(t, postData, regIds, expectedPayload)
+}
+
+func TestToGCMPayloadWithCommonParameters(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":  "somegroup",
+		"other":     "value",
+		"other.foo": "bar",
+		"ttl":       "5",
+		// GCM module should ignore anything it doesn't recognize begining with "uniqush.", those are reserved.
+		"uniqush.payload.apns": "{}",
+		"uniqush.foo":          "foo",
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"other":"value","other.foo":"bar"},"time_to_live":5}`
+	testToGCMPayload(t, postData, regIds, expectedPayload)
+}
+
+// Test that it will be encoded properly if uniqush.payload.gcm is provided instead of uniqush.payload
+func TestToGCMPayloadNewWay(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":            "somegroup",
+		"uniqush.payload.gcm": `{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}}`,
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}},"time_to_live":3600}`
+	testToGCMPayload(t, postData, regIds, expectedPayload)
+}
+
+// Test that the push type isn't used as a fallback collapse key or anything else.
+func TestToGCMPayloadUsesMsggroupForCollapseKey(t *testing.T) {
+	postData := map[string]string{
+		"uniqush.payload.gcm": `{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}}`,
+		"msggroup":            "AMsgGroup",
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"AMsgGroup","data":{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}},"time_to_live":3600}`
+	testToGCMPayload(t, postData, regIds, expectedPayload)
+}


### PR DESCRIPTION
through "uniqush.payload.apns", "uniqush.payload.gcm", and "uniqush.payload.apns", respectively.

1. If those parameters exist, start using them **instead** of the existing method for building the (inner) data of the payload. This allows clients more flexibility to add custom data (E.g. nested objects in APNS payloads).
    The new version of the code should behave the same way as the old method if none of the POST data begins with "uniqush." (This PR rearranged the existing code and renamed some variables)
2. Add test cases for both methods of building payloads.
3. Start removing unrecognized POST fields beginning with "uniqush." from the payloads. E.g. don't accidentally include "uniqush.payload.gcm" in the inner body of an APNS payload.
4. Fix a bug in "content-available" for APNS. This should be passed as a number. https://developer.apple.com/library/ios/documentation/NetworkingInternet/Conceptual/RemoteNotificationsPG/Chapters/TheNotificationPayload.html