### PR TITLE
Indicate that the  DeliveryPoint was modified #113

### DIFF
--- a/pushbackend.go
+++ b/pushbackend.go
@@ -171,7 +171,7 @@ func (self *PushBackEnd) fixError(reqId string, remoteAddr string, event error, 
 			handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Subscriber: &sub, Service: &service, DeliveryPoint: &dpName, Code: UNIQUSH_ERROR_UPDATE_DELIVERY_POINT, ErrorMsg: strPtrOfErr(e)})
 		} else {
 			logger.Infof("Service=%v Subscriber=%v DeliveryPoint=%v Update Success", service, sub, dpName)
-			handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Subscriber: &sub, Service: &service, DeliveryPoint: &dpName, Code: UNIQUSH_SUCCESS})
+			handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Subscriber: &sub, Service: &service, DeliveryPoint: &dpName, Code: UNIQUSH_SUCCESS, ModifiedDp: true})
 		}
 	case *push.InvalidRegistrationUpdate:
 		if err.Provider == nil || err.Destination == nil {

--- a/restapi_response.go
+++ b/restapi_response.go
@@ -39,6 +39,7 @@ type ApiResponseDetails struct {
 	MessageId           *string `json:"messageId,omitempty"`
 	Code                string  `json:"code"`
 	ErrorMsg            *string `json:"errorMsg,omitempty"`
+	ModifiedDp          bool    `json:"modifiedDp,omitempty"`
 }
 
 func strPtrOfErr(e error) *string {


### PR DESCRIPTION
Add a new boolean indicator “modifiedDp” to “successDetails” in case
the DeliveryPoint was modified (in case on canonical ID).

Example:
{"type":"Push","date":1461863706,"successCount":1,"failureCount":0,"drop
pedCount":0,"successDetails":[{"requestId":"5722451a-p2SvjxrnRGLTEYQ4U7m
INg==","service":"ps001","from":"10.0.0.102:55851","subscriber”:”xxx”,”p
ushServiceProvider":"gcm:yyy”,”deliveryPoint":"gcm:zzz”,”messageId":"gcm
:iii”,”code":"UNIQUSH_SUCCESS","modifiedDp":true}],"failureDetails":[],"
droppedDetails":[]}