### PR TITLE
Set proper content type for REST API responses

### DIFF
--- a/build/build-uniqush-push.sh
+++ b/build/build-uniqush-push.sh
@@ -13,7 +13,7 @@ if [ -d "$TEMP" ]; then
 	rm -rf "$TEMP"
 fi
 
-GOBIN="$TEMP/bin" GOPATH="$TEMP" go get github.com/uniqush/uniqush-push
+GOBIN="$TEMP/bin" GOPATH="$TEMP" go get github.com/Interactive3G/uniqush-push
 
 VERSION=`"$TEMP/bin/uniqush-push" --version | sed 's/uniqush-push //'`
 
@@ -24,8 +24,8 @@ mkdir -p "$BUILD/etc/uniqush/"
 ARCH="`uname -m`"
 
 cp "$TEMP/bin/uniqush-push" "$BUILD/usr/bin"
-cp "$TEMP/src/github.com/uniqush/uniqush-push/conf/uniqush-push.conf" "$BUILD/etc/uniqush"
-cp "$TEMP/src/github.com/uniqush/uniqush-push/LICENSE" "$LICENSE"
+cp "$TEMP/src/github.com/Interactive3G/uniqush-push/conf/uniqush-push.conf" "$BUILD/etc/uniqush"
+cp "$TEMP/src/github.com/Interactive3G/uniqush-push/LICENSE" "$LICENSE"
 
 fpm -s dir -t rpm -v "$VERSION" -n uniqush-push --license="$LICENSE" --maintainer="Nan Deng" --vendor "uniqush" --url="http://uniqush.org" --category Network --description "Uniqush is a free and open source software which provides a unified push service for server-side notification to apps on mobile devices" -a "$ARCH" -C "$BUILD" .
 
@@ -36,7 +36,7 @@ TARBALLDIR=`pwd`/"$TARBALLNAME"
 mkdir -p "$TARBALLDIR"
 cp "$LICENSE" "$TARBALLDIR"
 cp "$TEMP/bin/uniqush-push" "$TARBALLDIR"
-cp "$TEMP/src/github.com/uniqush/uniqush-push/conf/uniqush-push.conf" "$TARBALLDIR/uniqush-push.conf"
+cp "$TEMP/src/github.com/Interactive3G/uniqush-push/conf/uniqush-push.conf" "$TARBALLDIR/uniqush-push.conf"
 
 cat > "$TARBALLNAME/install.sh" << EOF
 #!/bin/sh

--- a/conf/uniqush-push.conf
+++ b/conf/uniqush-push.conf
@@ -1,41 +1,41 @@
-logfile=/var/log/uniqush
+logfile=/var/log/uniqush.log
 # Log level: verbose, standard, 
 [WebFrontend]
 log=on
-loglevel=standard
-addr=localhost:9898
+loglevel=verbose
+addr=192.168.1.178:9898
 
 [AddPushServiceProvider]
 log=on
-loglevel=standard
+loglevel=verbose
 
 [RemovePushServiceProvider]
 log=on
-loglevel=standard
+loglevel=verbose
 
 [PSPs]
 log=on
-loglevel=standard
+loglevel=verbose
 
 [Subscribe]
 log=on
-loglevel=standard
+loglevel=verbose
 
 [Unsubscribe]
 log=on
-loglevel=standard
+loglevel=verbose
 
 [Push]
 log=on
-loglevel=standard
+loglevel=verbose
 
 [Subscriptions]
 log=on
-loglevel=standard
+loglevel=verbose
 
 [Services]
 log=on
-loglevel=standard
+loglevel=verbose
 
 [Database]
 engine=redis
@@ -44,4 +44,3 @@ name=0
 everysec=600
 leastdirty=10
 cachesize=1024
-

--- a/restapi.go
+++ b/restapi.go
@@ -383,6 +383,7 @@ func (self *RestAPI) rebuildServiceSet(logger log.Logger) []byte {
 func (self *RestAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	remoteAddr := r.RemoteAddr
+	w.Header().Set("Content-Type","application/json")
 
 	switch r.URL.Path {
 	case QUERY_SUBSCRIPTIONS_URL:


### PR DESCRIPTION
Using Jax-ws (Jersey) client to access uniqush REST API and it fails to automatically map the response to a Java object because of the content type "text/plain". This change solves this issue
