### PR TITLE
Add /previewpush endpoint to preview payloads sent to push services.

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -38,6 +38,7 @@ const (
 	LOGGER_PUSH
 	LOGGER_SUBSCRIPTIONS
 	LOGGER_SERVICES
+	LOGGER_PREVIEW
 	LOGGER_NR_LOGGERS
 )
 
@@ -198,6 +199,12 @@ func LoadLoggers(c *conf.ConfigFile) (loggers []log.Logger, err error) {
 		return
 	}
 	loggers[LOGGER_SERVICES], err = loadLogger(logfile, c, "Services", "[Services]")
+	if err != nil {
+		loggers = nil
+		return
+	}
+
+	loggers[LOGGER_PREVIEW], err = loadLogger(logfile, c, "Preview", "[Preview]")
 	if err != nil {
 		loggers = nil
 		return

--- a/push/pushpeer_test.go
+++ b/push/pushpeer_test.go
@@ -58,6 +58,11 @@ func (t *testPushServiceType) Push(*PushServiceProvider, <-chan *DeliveryPoint, 
 	fmt.Print("Push!\n")
 }
 
+func (t *testPushServiceType) Preview(*Notification) ([]byte, PushError) {
+	fmt.Print("Preview!\n")
+	return []byte("{}"), nil
+}
+
 func (t *testPushServiceType) SetErrorReportChan(chan<- PushError) {}
 
 func TestPushPeer(t *testing.T) {

--- a/push/pushservicemngr.go
+++ b/push/pushservicemngr.go
@@ -195,6 +195,14 @@ func (m *PushServiceManager) Push(psp *PushServiceProvider, dpQueue <-chan *Deli
 	wg.Wait()
 }
 
+func (m *PushServiceManager) Preview(ptname string, notif *Notification) ([]byte, PushError) {
+	if pst, ok := m.serviceTypes[ptname]; ok && pst != nil {
+		return pst.pst.Preview(notif)
+	} else {
+		return nil, NewErrorf("No push service type %q", ptname)
+	}
+}
+
 func (m *PushServiceManager) SetErrorReportChan(errChan chan<- PushError) {
 	m.errChan = errChan
 	for _, t := range m.serviceTypes {

--- a/push/pushservicetype.go
+++ b/push/pushservicetype.go
@@ -70,6 +70,9 @@ type PushServiceType interface {
 	// once the works done.
 	Push(*PushServiceProvider, <-chan *DeliveryPoint, chan<- *PushResult, *Notification)
 
+	// Preview the bytes of a notification, for placeholder subscriber data. This makes no service/database calls.
+	Preview(*Notification) ([]byte, PushError)
+
 	// Set a channel for the push service provider so that it can report error even if
 	// there is no method call on it.
 	// The type of the errors sent may cause the push service manager to take various actions.

--- a/pushbackend.go
+++ b/pushbackend.go
@@ -380,3 +380,7 @@ func (self *PushBackEnd) pushImpl(reqId string, remoteAddr string, service strin
 	}
 	wg.Wait()
 }
+
+func (self *PushBackEnd) Preview(ptname string, notif *push.Notification) ([]byte, push.PushError) {
+	return self.psm.Preview(ptname, notif)
+}

--- a/restapi.go
+++ b/restapi.go
@@ -21,9 +21,11 @@ import (
 	"crypto/rand"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -66,6 +68,7 @@ const (
 	ADD_DELIVERY_POINT_TO_SERVICE_URL           = "/subscribe"
 	REMOVE_DELIVERY_POINT_FROM_SERVICE_URL      = "/unsubscribe"
 	PUSH_NOTIFICATION_URL                       = "/push"
+	PREVIEW_PUSH_NOTIFICATION_URL               = "/previewpush"
 	STOP_PROGRAM_URL                            = "/stop"
 	VERSION_INFO_URL                            = "/version"
 	QUERY_NUMBER_OF_DELIVERY_POINTS_URL         = "/nrdp"
@@ -214,26 +217,8 @@ func (self *RestAPI) changeSubscription(kv map[string]string, logger log.Logger,
 	}
 }
 
-func (self *RestAPI) pushNotification(reqId string, kv map[string]string, perdp map[string][]string, logger log.Logger, remoteAddr string, handler ApiResponseHandler) {
-	service, err := getServiceFromMap(kv, true)
-	if err != nil {
-		logger.Errorf("RequestId=%v From=%v Cannot get service name: %v; %v", reqId, remoteAddr, service, err)
-		handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SERVICE})
-		return
-	}
-	subs, err := getSubscribersFromMap(kv, false)
-	if err != nil {
-		logger.Errorf("RequestId=%v From=%v Service=%v Cannot get subscriber: %v", reqId, remoteAddr, service, err)
-		handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SUBSCRIBER})
-		return
-	}
-	if len(subs) == 0 {
-		logger.Errorf("RequestId=%v From=%v Service=%v NoSubscriber", reqId, remoteAddr, service)
-		handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_NO_SUBSCRIBER})
-		return
-	}
-
-	notif := push.NewEmptyNotification()
+func (self *RestAPI) buildNotificationFromKV(reqId string, kv map[string]string, logger log.Logger, remoteAddr string, service string, subs []string) (notif *push.Notification, details *ApiResponseDetails, err error) {
+	notif = push.NewEmptyNotification()
 
 	for k, v := range kv {
 		if len(v) <= 0 {
@@ -261,13 +246,76 @@ func (self *RestAPI) pushNotification(reqId string, kv map[string]string, perdp 
 
 	if notif.IsEmpty() {
 		logger.Errorf("RequestId=%v From=%v Service=%v NrSubscribers=%v Subscribers=\"%+v\" EmptyNotification", reqId, remoteAddr, service, len(subs), subs)
-		handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_EMPTY_NOTIFICATION})
+		details = &ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_EMPTY_NOTIFICATION}
+		return nil, details, errors.New("empty notification")
+	}
+	return notif, nil, nil
+}
+
+func (self *RestAPI) pushNotification(reqId string, kv map[string]string, perdp map[string][]string, logger log.Logger, remoteAddr string, handler ApiResponseHandler) {
+	service, err := getServiceFromMap(kv, true)
+	if err != nil {
+		logger.Errorf("RequestId=%v From=%v Cannot get service name: %v; %v", reqId, remoteAddr, service, err)
+		handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SERVICE})
+		return
+	}
+	subs, err := getSubscribersFromMap(kv, false)
+	if err != nil {
+		logger.Errorf("RequestId=%v From=%v Service=%v Cannot get subscriber: %v", reqId, remoteAddr, service, err)
+		handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_CANNOT_GET_SUBSCRIBER})
+		return
+	}
+	if len(subs) == 0 {
+		logger.Errorf("RequestId=%v From=%v Service=%v NoSubscriber", reqId, remoteAddr, service)
+		handler.AddDetailsToHandler(ApiResponseDetails{RequestId: &reqId, From: &remoteAddr, Service: &service, Code: UNIQUSH_ERROR_NO_SUBSCRIBER})
+		return
+	}
+
+	notif, details, err := self.buildNotificationFromKV(reqId, kv, logger, remoteAddr, service, subs)
+	if err != nil {
+		handler.AddDetailsToHandler(*details)
 		return
 	}
 
 	logger.Infof("RequestId=%v From=%v Service=%v NrSubscribers=%v Subscribers=\"%+v\"", reqId, remoteAddr, service, len(subs), subs)
 
 	self.backend.Push(reqId, remoteAddr, service, subs, notif, perdp, logger, handler)
+}
+
+// preview takes key-value pairs (pushservicetype, plus data for building the payload), a logger, and logging data.
+func (self *RestAPI) preview(reqId string, kv map[string]string, logger log.Logger, remoteAddr string) PreviewApiResponseDetails {
+	ptname, ok := kv["pushservicetype"]
+	if !ok || ptname == "" {
+		msg := "Must specify a known pushservicetype"
+		return PreviewApiResponseDetails{Code: UNIQUSH_ERROR_NO_PUSH_SERVICE_TYPE, ErrorMsg: &msg}
+	}
+	delete(kv, "pushservicetype")
+	notif, details, err := self.buildNotificationFromKV(reqId, kv, logger, remoteAddr, "placeholderservice", []string{})
+	if err != nil {
+		return PreviewApiResponseDetails{
+			Code:     details.Code,
+			ErrorMsg: details.ErrorMsg,
+		}
+	}
+
+	data, err := self.backend.Preview(ptname, notif)
+	if err != nil {
+		errmsg := err.Error()
+		return PreviewApiResponseDetails{Code: UNIQUSH_ERROR_GENERIC, ErrorMsg: &errmsg}
+	}
+	return PreviewApiResponseDetails{Code: UNIQUSH_SUCCESS, Payload: apiBytesToObject(data)}
+}
+
+func apiBytesToObject(data []byte) interface{} {
+	// currently, all types are JSON. In the future, there may be non-JSON payloads in a protocol.
+	// Either return a string or an object (to be converted to JSON again by the API)
+	var obj interface{}
+	obj = nil
+	err := json.Unmarshal(data, &obj)
+	if err != nil || obj == nil {
+		return string(data)
+	}
+	return obj
 }
 
 func (self *RestAPI) stop(w io.Writer, remoteAddr string) {
@@ -380,6 +428,25 @@ func (self *RestAPI) rebuildServiceSet(logger log.Logger) []byte {
 	return json
 }
 
+func parseKV(form url.Values) (kv map[string]string, perdp map[string][]string) {
+	kv = make(map[string]string, len(form))
+	perdp = make(map[string][]string, 3)
+	perdpPrefix := "uniqush.perdp."
+	for k, v := range form {
+		if len(k) > len(perdpPrefix) {
+			if k[:len(perdpPrefix)] == perdpPrefix {
+				key := k[len(perdpPrefix):]
+				perdp[key] = v
+				continue
+			}
+		}
+		if len(v) > 0 {
+			kv[k] = v[0]
+		}
+	}
+	return kv, perdp
+}
+
 func (self *RestAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	defer r.Body.Close()
 	remoteAddr := r.RemoteAddr
@@ -403,6 +470,18 @@ func (self *RestAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		n := self.numberOfDeliveryPoints(r.Form, self.loggers[LOGGER_WEB], remoteAddr)
 		fmt.Fprintf(w, "%v\r\n", n)
 		return
+	case PREVIEW_PUSH_NOTIFICATION_URL:
+		r.ParseForm()
+		kv, _ := parseKV(r.Form)
+		rid := randomUniqId()
+		details := self.preview(rid, kv, self.loggers[LOGGER_PREVIEW], remoteAddr)
+		bytes, err := json.Marshal(details)
+		if err != nil {
+			fmt.Fprintf(w, "%s\r\n", string(err.Error()))
+			return
+		}
+		fmt.Fprintf(w, "%s\r\n", string(bytes))
+		return
 	case VERSION_INFO_URL:
 		fmt.Fprintf(w, "%v\r\n", self.version)
 		self.loggers[LOGGER_WEB].Infof("Checked version from %v", remoteAddr)
@@ -412,21 +491,7 @@ func (self *RestAPI) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	r.ParseForm()
-	kv := make(map[string]string, len(r.Form))
-	perdp := make(map[string][]string, 3)
-	perdpPrefix := "uniqush.perdp."
-	for k, v := range r.Form {
-		if len(k) > len(perdpPrefix) {
-			if k[:len(perdpPrefix)] == perdpPrefix {
-				key := k[len(perdpPrefix):]
-				perdp[key] = v
-				continue
-			}
-		}
-		if len(v) > 0 {
-			kv[k] = v[0]
-		}
-	}
+	kv, perdp := parseKV(r.Form)
 
 	self.waitGroup.Add(1)
 	defer self.waitGroup.Done()
@@ -472,6 +537,7 @@ func (self *RestAPI) Run(addr string, stopChan chan<- bool) {
 	http.Handle(REMOVE_DELIVERY_POINT_FROM_SERVICE_URL, self)
 	http.Handle(REMOVE_PUSH_SERVICE_PROVIDER_TO_SERVICE_URL, self)
 	http.Handle(PUSH_NOTIFICATION_URL, self)
+	http.Handle(PREVIEW_PUSH_NOTIFICATION_URL, self)
 	http.Handle(QUERY_NUMBER_OF_DELIVERY_POINTS_URL, self)
 	http.Handle(QUERY_SUBSCRIPTIONS_URL, self)
 	http.Handle(QUERY_PUSH_SERVICE_PROVIDERS, self)

--- a/restapi_response.go
+++ b/restapi_response.go
@@ -27,6 +27,7 @@ const (
 	UNIQUSH_ERROR_NO_PUSH_SERVICE_PROVIDER = "UNIQUSH_ERROR_NO_PUSH_SERVICE_PROVIDER"
 	UNIQUSH_ERROR_NO_SERVICE               = "UNIQUSH_ERROR_NO_SERVICE"
 	UNIQUSH_ERROR_NO_SUBSCRIBER            = "UNIQUSH_ERROR_NO_SUBSCRIBER"
+	UNIQUSH_ERROR_NO_PUSH_SERVICE_TYPE     = "UNIQUSH_ERROR_NO_PUSH_SERVICE_TYPE"
 )
 
 type ApiResponseDetails struct {
@@ -40,6 +41,12 @@ type ApiResponseDetails struct {
 	Code                string  `json:"code"`
 	ErrorMsg            *string `json:"errorMsg,omitempty"`
 	ModifiedDp          bool    `json:"modifiedDp,omitempty"`
+}
+
+type PreviewApiResponseDetails struct {
+	Code     string      `json:"code"`
+	Payload  interface{} `json:"payload,omitempty"`
+	ErrorMsg *string     `json:"errorMsg,omitempty"`
 }
 
 func strPtrOfErr(e error) *string {

--- a/srv/apns/binary_api/processor_test.go
+++ b/srv/apns/binary_api/processor_test.go
@@ -41,6 +41,9 @@ func (self *MockAPNSPushServiceType) Name() string {
 func (self *MockAPNSPushServiceType) Push(*push.PushServiceProvider, <-chan *push.DeliveryPoint, chan<- *push.PushResult, *push.Notification) {
 	panic("Not implemented")
 }
+func (self *MockAPNSPushServiceType) Preview(*push.Notification) ([]byte, push.PushError) {
+	panic("Not implemented")
+}
 func (self *MockAPNSPushServiceType) SetErrorReportChan(errChan chan<- push.PushError) {
 	panic("Not implemented")
 }

--- a/srv/apns/push_service.go
+++ b/srv/apns/push_service.go
@@ -198,6 +198,13 @@ func (self *pushService) waitResults(psp *push.PushServiceProvider, dpList []*pu
 	}
 }
 
+// Returns a JSON APNS payload, for a dummy device token
+func (self *pushService) Preview(notif *push.Notification) ([]byte, push.PushError) {
+	return toAPNSPayload(notif)
+}
+
+// Push will read all of the delivery points to send to from dpQueue and send responses on resQueue before closing the channel. If the notification data is invalid,
+// it will send only one response.
 func (self *pushService) Push(psp *push.PushServiceProvider, dpQueue <-chan *push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
 	defer close(resQueue)
 	// Profiling

--- a/srv/apns/push_service_test.go
+++ b/srv/apns/push_service_test.go
@@ -350,6 +350,37 @@ func TestToAPNSPayloadAllParams(t *testing.T) {
 	}
 }
 
+func TestPreview(t *testing.T) {
+	expectedJSON := `{"aps":{"alert":{"action-loc-key":"foo","body":"hello world","launch-image":"Default2.png","loc-args":["one","two"],"loc-key":"bar"},"badge":777,"content-available":1,"sound":"hi.wav"},"myKey":"myValue"}`
+	notification := &push.Notification{
+		Data: map[string]string{
+			"msg":               "hello world",
+			"action-loc-key":    "foo",
+			"loc-key":           "bar",
+			"loc-args":          "one,two",
+			"badge":             "777",
+			"sound":             "hi.wav",
+			"content-available": "1",
+			"img":               "Default2.png",
+			"id":                "unused",
+			"expiry":            "unused",
+			"ttl":               "42",
+			"myKey":             "myValue",
+			// Keys beginning with "uniqush." are reserved by uniqush.
+			"uniqush.foo": "ignored",
+		},
+	}
+	_, _, service, _ := commonAPNSMocks(APNS_UNSUBSCRIBE)
+	defer service.Finalize()
+	payload, err := service.Preview(notification)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !bytes.Equal([]byte(expectedJSON), payload) {
+		t.Errorf("Expected %s, Got %s", expectedJSON, string(payload))
+	}
+}
+
 func expectMapEquals(t *testing.T, expected map[string]string, actual map[string]string, description string) {
 	for k, v := range expected {
 		actualV, ok := actual[k]

--- a/srv/gcm.go
+++ b/srv/gcm.go
@@ -470,6 +470,10 @@ func (self *gcmPushService) Push(psp *push.PushServiceProvider, dpQueue <-chan *
 	close(resQueue)
 }
 
+func (self *gcmPushService) Preview(notif *push.Notification) ([]byte, push.PushError) {
+	return toGCMPayload(notif, []string{"placeholderRegId"})
+}
+
 func (self *gcmPushService) SetErrorReportChan(errChan chan<- push.PushError) {
 	return
 }


### PR DESCRIPTION
`/previewpush` accepts the same payload query params as `push`.

However, it does not accept subscribers or services.
Instead, it requires the pushservicetype param (apns, gcm, or adm)
Being able to see what Uniqush is sending is useful for
debugging iOS,Android,etc. client issues handling/parsing notifications.
(Note: Fields such as TTL are outside of the JSON payload for APNS)

Subscriber data, if part of the "payload", is replaced with dummy
subscriber data in the returned result.

Add tests, update mocks to implement Preview.

Use reflect.DeepEqual for a unit test - The order of keys is not
guaranteed.
