### PR TITLE
FCM support (refactored)

### DIFF
--- a/main.go
+++ b/main.go
@@ -33,6 +33,7 @@ var uniqushPushVersion = "uniqush-push 2.2.0"
 
 func installPushServices() {
 	srv.InstallGCM()
+	srv.InstallFCM()
 	srv.InstallAPNS()
 	srv.InstallADM()
 }

--- a/srv/cloud_messaging/cloud_messaging.go
+++ b/srv/cloud_messaging/cloud_messaging.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011-2013 Nan Deng
+ * Copyright 2013-2017 Uniqush Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/srv/cloud_messaging/cloud_messaging.go
+++ b/srv/cloud_messaging/cloud_messaging.go
@@ -1,0 +1,469 @@
+/*
+ * Copyright 2011-2013 Nan Deng
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+
+ * This contains implementation details common to GCM and FCM.
+ * Parts of this will be refactored as new features are added for FCM/GCM.
+ */
+package cloud_messaging
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/uniqush/uniqush-push/push"
+)
+
+// HTTPClient is a mockable interface for the parts of http.Client used by the GCM and FCM modules.
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+var _ HTTPClient = &http.Client{}
+
+type PushServiceBase struct {
+	// There is only one Transport and one Client for connecting to gcm or fcm, shared by the set of PSPs with pushservicetype=fcm (whether or not this is using a sandbox)
+	// (Expose functionality of this client through public methods)
+	client HTTPClient
+	// const: "GCM" or "FCM", for logging
+	acronym string
+	// const: "uniqush.payload.fcm" or "uniqush.payload.gcm"
+	rawPayloadKey string
+	// const: GCM/FCM endpoint. "https://..../push"
+	serviceURL string
+	// const: "gcm" or "fcm", for API requests to uniqush and API responses, as well as logging.
+	pushServiceName string
+}
+
+// Close all open connections.
+func (p *PushServiceBase) Finalize() {
+	if client, isClient := p.client.(*http.Client); isClient {
+		if transport, ok := client.Transport.(*http.Transport); ok {
+			transport.CloseIdleConnections()
+		}
+	}
+}
+
+func (g *PushServiceBase) OverrideClient(client HTTPClient) {
+	g.client = client
+}
+
+// Builds a common base.
+// Note: Make sure that this can be copied by value (it's a collection of poitners right now).
+// If it can no longer be copied by value, // change to an initializer function.
+func MakePushServiceBase(acronym string, rawPayloadKey string, serviceURL string, pushServiceName string) PushServiceBase {
+	conf := &tls.Config{InsecureSkipVerify: false}
+	tr := &http.Transport{
+		TLSClientConfig:     conf,
+		TLSHandshakeTimeout: time.Second * 5,
+		// TODO: Make this configurable later on? The default of 2 is too low.
+		// goals: (1) new connections should not be opened and closed frequently, (2) we should not run out of sockets.
+		// This doesn't seem to need much tuning. The number of connections open at a given time seems to be less than 500, even when sending hundreds of pushes per second.
+		MaxIdleConnsPerHost: 500,
+	}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   time.Second * 10, // Add a timeout for all requests, in case of network issues.
+	}
+	return PushServiceBase{
+		client:          client,
+		acronym:         acronym,
+		rawPayloadKey:   rawPayloadKey,
+		serviceURL:      serviceURL,
+		pushServiceName: pushServiceName,
+	}
+}
+
+// Builds an FCM/GCM delivery point from key-value pairs provided by an API call to uniqush-push.
+func (p *PushServiceBase) BuildDeliveryPointFromMap(kv map[string]string,
+	dp *push.DeliveryPoint) error {
+	if service, ok := kv["service"]; ok && len(service) > 0 {
+		dp.FixedData["service"] = service
+	} else {
+		return errors.New("NoService")
+	}
+	if sub, ok := kv["subscriber"]; ok && len(sub) > 0 {
+		dp.FixedData["subscriber"] = sub
+	} else {
+		return errors.New("NoSubscriber")
+	}
+	if account, ok := kv["account"]; ok && len(account) > 0 {
+		dp.FixedData["account"] = account
+	}
+	if regid, ok := kv["regid"]; ok && len(regid) > 0 {
+		dp.FixedData["regid"] = regid
+	} else {
+		return errors.New("NoRegId")
+	}
+
+	return nil
+}
+
+// Data used by GCM or FCM. Currently the same.
+type CMData struct {
+	RegIDs         []string               `json:"registration_ids"`
+	CollapseKey    string                 `json:"collapse_key,omitempty"`
+	Data           map[string]interface{} `json:"data"` // For compatibility with other GCM platforms(e.g. iOS), should always be a map[string]string
+	DelayWhileIdle bool                   `json:"delay_while_idle,omitempty"`
+	TimeToLive     uint                   `json:"time_to_live,omitempty"`
+}
+
+func (d *CMData) String() string {
+	ret, err := json.Marshal(d)
+	if err != nil {
+		return ""
+	}
+	return string(ret)
+}
+
+// validateRawCMData verifies that the user-provided JSON payload is a valid JSON object.
+func validateRawCMData(payload string) (map[string]interface{}, push.PushError) {
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(payload), &data)
+	if data == nil {
+		return nil, push.NewBadNotificationWithDetails(fmt.Sprintf("Could not parse GCM/FCM data: %v", err))
+	}
+	return data, nil
+}
+
+// GCM/FCM result. Currently the same for both GCM and FCM.
+type CMResult struct {
+	MulticastID  uint64              `json:"multicast_id"`
+	Success      uint                `json:"success"`
+	Failure      uint                `json:"failure"`
+	CanonicalIDs uint                `json:"canonical_ids"`
+	Results      []map[string]string `json:"results"`
+}
+
+func (self *PushServiceBase) Name() string {
+	return self.pushServiceName
+}
+
+func (self *PushServiceBase) ToCMPayload(notif *push.Notification, regIds []string) ([]byte, push.PushError) {
+	postData := notif.Data
+	payload := new(CMData)
+	payload.RegIDs = regIds
+
+	// TTL: default is one hour
+	payload.TimeToLive = 60 * 60
+	payload.DelayWhileIdle = false
+
+	if mgroup, ok := postData["msggroup"]; ok {
+		payload.CollapseKey = mgroup
+	} else {
+		payload.CollapseKey = ""
+	}
+
+	if ttlStr, ok := postData["ttl"]; ok {
+		ttl, err := strconv.ParseUint(ttlStr, 10, 32)
+		if err == nil {
+			payload.TimeToLive = uint(ttl)
+		}
+	}
+
+	if rawData, ok := postData[self.rawPayloadKey]; ok {
+		// Could add uniqush.notification.gcm/fcm as another optional payload, to conform to GCM spec: https://developers.google.com/cloud-messaging/http-server-ref#send-downstream
+		data, err := validateRawCMData(rawData)
+		if err != nil {
+			return nil, err
+		}
+		payload.Data = data
+	} else {
+		nr_elem := len(postData)
+		payload.Data = make(map[string]interface{}, nr_elem)
+
+		for k, v := range postData {
+			if strings.HasPrefix(k, "uniqush.") { // The "uniqush." keys are reserved for uniqush use.
+				continue
+			}
+			switch k {
+			case "msggroup", "ttl":
+				continue
+			default:
+				payload.Data[k] = v
+			}
+		}
+	}
+
+	jpayload, e0 := json.Marshal(payload)
+	if e0 != nil {
+		return nil, push.NewErrorf("Error converting payload to JSON: %v", e0)
+	}
+	return jpayload, nil
+}
+
+func extractRegIds(dpList []*push.DeliveryPoint) []string {
+	regIds := make([]string, 0, len(dpList))
+
+	for _, dp := range dpList {
+		regIds = append(regIds, dp.VolatileData["regid"])
+	}
+	return regIds
+}
+
+func sendErrToEachDP(psp *push.PushServiceProvider, dpList []*push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification, err push.PushError) {
+	for _, dp := range dpList {
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+
+		res.Err = err
+		res.Destination = dp
+		resQueue <- res
+	}
+}
+
+func (self *PushServiceBase) multicast(psp *push.PushServiceProvider, dpList []*push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
+	if len(dpList) == 0 {
+		return
+	}
+	regIds := extractRegIds(dpList)
+
+	jpayload, e0 := self.ToCMPayload(notif, regIds)
+
+	if e0 != nil {
+		sendErrToEachDP(psp, dpList, resQueue, notif, e0)
+		return
+	}
+
+	req, e1 := http.NewRequest("POST", self.serviceURL, bytes.NewReader(jpayload))
+	if req != nil {
+		defer req.Body.Close()
+	}
+	if e1 != nil {
+		http_err := push.NewErrorf("Error constructing HTTP request: %v", e1)
+		sendErrToEachDP(psp, dpList, resQueue, notif, http_err)
+		return
+	}
+
+	apikey := psp.VolatileData["apikey"]
+
+	req.Header.Set("Authorization", "key="+apikey)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Perform a request, using a connection from the connection pool of a shared http.Client instance.
+	r, e2 := self.client.Do(req)
+	if r != nil {
+		defer r.Body.Close()
+	}
+	// TODO: Move this into two steps: sending and processing result
+	if e2 != nil {
+		for _, dp := range dpList {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Content = notif
+
+			res.Destination = dp
+			if err, ok := e2.(net.Error); ok {
+				// Temporary error. Try to recover
+				if err.Temporary() {
+					after := 3 * time.Second
+					res.Err = push.NewRetryErrorWithReason(psp, dp, notif, after, err)
+				}
+			} else if err, ok := e2.(*net.DNSError); ok {
+				// DNS error, try to recover it by retry
+				after := 3 * time.Second
+				res.Err = push.NewRetryErrorWithReason(psp, dp, notif, after, err)
+
+			} else {
+				res.Err = push.NewErrorf("Unrecoverable HTTP error sending to FCM: %v", e2)
+			}
+			resQueue <- res
+		}
+		return
+	}
+	// TODO: How does this work if there are multiple delivery points in one request to GCM/FCM?
+	new_auth_token := r.Header.Get("Update-Client-Auth")
+	if new_auth_token != "" && apikey != new_auth_token {
+		psp.VolatileData["apikey"] = new_auth_token
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = push.NewPushServiceProviderUpdate(psp)
+		resQueue <- res
+	}
+
+	switch r.StatusCode {
+	case 500, 503:
+		/* TODO extract the retry after field */
+		after := 0 * time.Second
+		for _, dp := range dpList {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Content = notif
+			res.Destination = dp
+			err := push.NewRetryError(psp, dp, notif, after)
+			res.Err = err
+			resQueue <- res
+		}
+		return
+	case 401:
+		err := push.NewBadPushServiceProvider(psp)
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = err
+		resQueue <- res
+		return
+	case 400:
+		err := push.NewBadNotification()
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = err
+		resQueue <- res
+		return
+	}
+
+	contents, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = push.NewErrorf("Failed to read %s response: %v", self.acronym, err)
+		resQueue <- res
+		return
+	}
+
+	var result CMResult
+	err = json.Unmarshal(contents, &result)
+
+	if err != nil {
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = push.NewErrorf("Failed to decode %s response: %v", self.acronym, err)
+		resQueue <- res
+		return
+	}
+
+	self.handleCMMulticastResults(psp, dpList, resQueue, notif, result.Results)
+}
+
+func (self *PushServiceBase) handleCMMulticastResults(psp *push.PushServiceProvider, dpList []*push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification, results []map[string]string) {
+	for i, r := range results {
+		if i >= len(dpList) {
+			break
+		}
+		dp := dpList[i]
+		if errmsg, ok := r["error"]; ok {
+			switch errmsg {
+			case "Unavailable":
+				after, _ := time.ParseDuration("2s")
+				res := new(push.PushResult)
+				res.Provider = psp
+				res.Content = notif
+				res.Destination = dp
+				res.Err = push.NewRetryError(psp, dp, notif, after)
+				resQueue <- res
+			case "NotRegistered":
+				res := new(push.PushResult)
+				res.Provider = psp
+				res.Err = push.NewUnsubscribeUpdate(psp, dp)
+				res.Content = notif
+				res.Destination = dp
+				resQueue <- res
+			case "InvalidRegistration":
+				res := new(push.PushResult)
+				res.Err = push.NewInvalidRegistrationUpdate(psp, dp)
+				res.Content = notif
+				res.Destination = dp
+				resQueue <- res
+			default:
+				res := new(push.PushResult)
+				res.Err = push.NewErrorf("FCMError: %v", errmsg)
+				res.Provider = psp
+				res.Content = notif
+				res.Destination = dp
+				resQueue <- res
+			}
+		}
+		if newregid, ok := r["registration_id"]; ok {
+			dp.VolatileData["regid"] = newregid
+			res := new(push.PushResult)
+			res.Err = push.NewDeliveryPointUpdate(dp)
+			res.Provider = psp
+			res.Content = notif
+			res.Destination = dp
+			resQueue <- res
+		}
+		if msgid, ok := r["message_id"]; ok {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Content = notif
+			res.Destination = dp
+			res.MsgId = fmt.Sprintf("%v:%v", psp.Name(), msgid)
+			resQueue <- res
+		}
+	}
+}
+
+func (self *PushServiceBase) Push(psp *push.PushServiceProvider, dpQueue <-chan *push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
+
+	maxNrDst := 1000
+	dpList := make([]*push.DeliveryPoint, 0, maxNrDst)
+	for dp := range dpQueue {
+		if psp.PushServiceName() != dp.PushServiceName() || psp.PushServiceName() != self.pushServiceName {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Destination = dp
+			res.Content = notif
+			res.Err = push.NewIncompatibleError()
+			resQueue <- res
+			continue
+		}
+		if _, ok := dp.VolatileData["regid"]; ok {
+			dpList = append(dpList, dp)
+		} else if regid, ok := dp.FixedData["regid"]; ok {
+			dp.VolatileData["regid"] = regid
+			dpList = append(dpList, dp)
+		} else {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Destination = dp
+			res.Content = notif
+			res.Err = push.NewBadDeliveryPoint(dp)
+			resQueue <- res
+			continue
+		}
+
+		if len(dpList) >= maxNrDst {
+			self.multicast(psp, dpList, resQueue, notif)
+			dpList = dpList[:0]
+		}
+	}
+	if len(dpList) > 0 {
+		self.multicast(psp, dpList, resQueue, notif)
+	}
+
+	close(resQueue)
+}
+
+func (self *PushServiceBase) Preview(notif *push.Notification) ([]byte, push.PushError) {
+	return self.ToCMPayload(notif, []string{"placeholderRegId"})
+}
+
+func (self *PushServiceBase) SetErrorReportChan(errChan chan<- push.PushError) {
+	return
+}

--- a/srv/cm_mocks.go
+++ b/srv/cm_mocks.go
@@ -1,0 +1,66 @@
+/**
+ * Mocks used by tests of both GCM and FCM.
+ */
+package srv
+
+import (
+	"bytes"
+	cm "github.com/uniqush/uniqush-push/srv/cloud_messaging"
+	"io"
+	"net/http"
+
+	// This is a collection of libraries for other tests
+	_ "testing"
+)
+
+type mockCMHTTPClient struct {
+	status       int
+	responseBody []byte
+	headers      map[string]string
+	requestError error
+	// Mocks for responses given json encoded request, TODO write expectations.
+	// mockCMResponses map[string]string
+	performed []*mockCMResponse
+}
+
+type mockCMResponse struct {
+	impl    *bytes.Reader
+	closed  bool
+	request *http.Request
+}
+
+var _ io.ReadCloser = &mockCMResponse{}
+
+func newMockCMResponse(contents []byte, request *http.Request) *mockCMResponse {
+	return &mockCMResponse{
+		impl:    bytes.NewReader(contents),
+		closed:  false,
+		request: request,
+	}
+}
+
+func (r *mockCMResponse) Read(p []byte) (n int, err error) {
+	return r.impl.Read(p)
+}
+
+func (r *mockCMResponse) Close() error {
+	r.closed = true
+	return nil
+}
+
+func (c *mockCMHTTPClient) Do(request *http.Request) (*http.Response, error) {
+	h := http.Header{}
+	for k, v := range c.headers {
+		h.Set(k, v)
+	}
+	body := newMockCMResponse(c.responseBody, request)
+	result := &http.Response{
+		StatusCode: c.status,
+		Body:       body,
+		Header:     h,
+	}
+	c.performed = append(c.performed, body)
+	return result, c.requestError
+}
+
+var _ cm.HTTPClient = &mockCMHTTPClient{}

--- a/srv/fcm.go
+++ b/srv/fcm.go
@@ -13,78 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
+
+ * This contains cloud messaging code specific to FCM.
+ * Implementation details common to GCM and FCM are kept in srv/cloud_messaging
  */
 
 package srv
 
 import (
-	"bytes"
-	"crypto/tls"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"net"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/uniqush/uniqush-push/push"
+	cm "github.com/uniqush/uniqush-push/srv/cloud_messaging"
 )
 
 const (
+	// FCM endpoint
 	fcmServiceURL string = "https://fcm.googleapis.com/fcm/send"
+	// payload key to extract from push requests to uniqush
+	fcmRawPayloadKey = "uniqush.payload.fcm"
+	// acronym for log messages
+	fcmAcronym = "FCM"
+	// push service type(name), for requests to uniqush
+	fcmPushServiceName = "fcm"
 )
-
-// FCMHTTPClient is a mockable interface for the parts of http.Client used by the GCM module.
-type FCMHTTPClient interface {
-	Do(*http.Request) (*http.Response, error)
-}
-
-var _ FCMHTTPClient = &http.Client{}
 
 type fcmPushService struct {
 	// There is only one Transport and one Client for connecting to fcm, shared by the set of PSPs with pushservicetype=fcm (whether or not this is using a sandbox)
-	client FCMHTTPClient
+	cm.PushServiceBase
 }
 
 var _ push.PushServiceType = &fcmPushService{}
 
 func newFCMPushService() *fcmPushService {
-	conf := &tls.Config{InsecureSkipVerify: false}
-	tr := &http.Transport{
-		TLSClientConfig:     conf,
-		TLSHandshakeTimeout: time.Second * 5,
-		// TODO: Make this configurable later on? The default of 2 is too low.
-		// goals: (1) new connections should not be opened and closed frequently, (2) we should not run out of sockets.
-		// This doesn't seem to need much tuning. The number of connections open at a given time seems to be less than 500, even when sending hundreds of pushes per second.
-		MaxIdleConnsPerHost: 500,
-	}
-	client := &http.Client{
-		Transport: tr,
-		Timeout:   time.Second * 10, // Add a timeout for all requests, in case of network issues.
-	}
 	return &fcmPushService{
-		client: client,
+		PushServiceBase: cm.MakePushServiceBase(fcmAcronym, fcmRawPayloadKey, fcmServiceURL, fcmPushServiceName),
 	}
 }
 
 func InstallFCM() {
 	psm := push.GetPushServiceManager()
 	psm.RegisterPushServiceType(newFCMPushService())
-}
-
-func (g *fcmPushService) OverrideClient(client FCMHTTPClient) {
-	g.client = client
-}
-
-func (p *fcmPushService) Finalize() {
-	if client, isClient := p.client.(*http.Client); isClient {
-		if transport, ok := client.Transport.(*http.Transport); ok {
-			transport.CloseIdleConnections()
-		}
-	}
 }
 
 func (p *fcmPushService) BuildPushServiceProviderFromMap(kv map[string]string,
@@ -102,372 +71,4 @@ func (p *fcmPushService) BuildPushServiceProviderFromMap(kv map[string]string,
 	}
 
 	return nil
-}
-
-func (p *fcmPushService) BuildDeliveryPointFromMap(kv map[string]string,
-	dp *push.DeliveryPoint) error {
-	if service, ok := kv["service"]; ok && len(service) > 0 {
-		dp.FixedData["service"] = service
-	} else {
-		return errors.New("NoService")
-	}
-	if sub, ok := kv["subscriber"]; ok && len(sub) > 0 {
-		dp.FixedData["subscriber"] = sub
-	} else {
-		return errors.New("NoSubscriber")
-	}
-	if account, ok := kv["account"]; ok && len(account) > 0 {
-		dp.FixedData["account"] = account
-	}
-	if regid, ok := kv["regid"]; ok && len(regid) > 0 {
-		dp.FixedData["regid"] = regid
-	} else {
-		return errors.New("NoRegId")
-	}
-
-	return nil
-}
-
-func (p *fcmPushService) Name() string {
-	return "fcm"
-}
-
-type fcmData struct {
-	RegIDs         []string               `json:"registration_ids"`
-	CollapseKey    string                 `json:"collapse_key,omitempty"`
-	Data           map[string]interface{} `json:"data"` // For compatibility with other FCM platforms(e.g. iOS), should always be a map[string]string
-	DelayWhileIdle bool                   `json:"delay_while_idle,omitempty"`
-	TimeToLive     uint                   `json:"time_to_live,omitempty"`
-}
-
-func (d *fcmData) String() string {
-	ret, err := json.Marshal(d)
-	if err != nil {
-		return ""
-	}
-	return string(ret)
-}
-
-type fcmResult struct {
-	MulticastID  uint64              `json:"multicast_id"`
-	Success      uint                `json:"success"`
-	Failure      uint                `json:"failure"`
-	CanonicalIDs uint                `json:"canonical_ids"`
-	Results      []map[string]string `json:"results"`
-}
-
-// validateRawFCMData verifies that the user-provided JSON payload is a valid JSON object.
-func validateRawFCMData(payload string) (map[string]interface{}, push.PushError) {
-	var data map[string]interface{}
-	err := json.Unmarshal([]byte(payload), &data)
-	if data == nil {
-		return nil, push.NewBadNotificationWithDetails(fmt.Sprintf("Could not parse FCM data: %v", err))
-	}
-	return data, nil
-}
-
-// toFCMPayload converts the notification data to a JSON-encoded string to POST to FCM.
-func toFCMPayload(notif *push.Notification, regIds []string) ([]byte, push.PushError) {
-	postData := notif.Data
-	payload := new(fcmData)
-	payload.RegIDs = regIds
-
-	// TTL: default is one hour
-	payload.TimeToLive = 60 * 60
-	payload.DelayWhileIdle = false
-
-	if mgroup, ok := postData["msggroup"]; ok {
-		payload.CollapseKey = mgroup
-	} else {
-		payload.CollapseKey = ""
-	}
-
-	if ttlStr, ok := postData["ttl"]; ok {
-		ttl, err := strconv.ParseUint(ttlStr, 10, 32)
-		if err == nil {
-			payload.TimeToLive = uint(ttl)
-		}
-	}
-
-	if rawData, ok := postData["uniqush.payload.fcm"]; ok {
-		// Could add uniqush.notification.fcm as another optional payload, to conform to FCM spec: https://developers.google.com/cloud-messaging/http-server-ref#send-downstream
-		data, err := validateRawFCMData(rawData)
-		if err != nil {
-			return nil, err
-		}
-		payload.Data = data
-	} else {
-		nr_elem := len(postData)
-		payload.Data = make(map[string]interface{}, nr_elem)
-
-		for k, v := range postData {
-			if strings.HasPrefix(k, "uniqush.") { // The "uniqush." keys are reserved for uniqush use.
-				continue
-			}
-			switch k {
-			case "msggroup", "ttl":
-				continue
-			default:
-				payload.Data[k] = v
-			}
-		}
-	}
-
-	jpayload, e0 := json.Marshal(payload)
-	if e0 != nil {
-		return nil, push.NewErrorf("Error converting payload to JSON: %v", e0)
-	}
-	return jpayload, nil
-
-}
-
-func (self *fcmPushService) multicast(psp *push.PushServiceProvider, dpList []*push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
-	if len(dpList) == 0 {
-		return
-	}
-
-	regIds := make([]string, 0, len(dpList))
-
-	for _, dp := range dpList {
-		regIds = append(regIds, dp.VolatileData["regid"])
-	}
-
-	jpayload, e0 := toFCMPayload(notif, regIds)
-
-	if e0 != nil {
-		for _, dp := range dpList {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-
-			res.Err = e0
-			res.Destination = dp
-			resQueue <- res
-		}
-		return
-	}
-
-	req, e1 := http.NewRequest("POST", fcmServiceURL, bytes.NewReader(jpayload))
-	if req != nil {
-		defer req.Body.Close()
-	}
-	if e1 != nil {
-		for _, dp := range dpList {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-
-			res.Err = push.NewErrorf("Error constructing HTTP request: %v", e1)
-			res.Destination = dp
-			resQueue <- res
-		}
-		return
-	}
-
-	apikey := psp.VolatileData["apikey"]
-
-	req.Header.Set("Authorization", "key="+apikey)
-	req.Header.Set("Content-Type", "application/json")
-
-	// Perform a request, using a connection from the connection pool of a shared http.Client instance.
-	r, e2 := self.client.Do(req)
-	if r != nil {
-		defer r.Body.Close()
-	}
-	if e2 != nil {
-		for _, dp := range dpList {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-
-			res.Destination = dp
-			if err, ok := e2.(net.Error); ok {
-				// Temporary error. Try to recover
-				if err.Temporary() {
-					after := 3 * time.Second
-					res.Err = push.NewRetryErrorWithReason(psp, dp, notif, after, err)
-				}
-			} else if err, ok := e2.(*net.DNSError); ok {
-				// DNS error, try to recover it by retry
-				after := 3 * time.Second
-				res.Err = push.NewRetryErrorWithReason(psp, dp, notif, after, err)
-
-			} else {
-				res.Err = push.NewErrorf("Unrecoverable HTTP error sending to FCM: %v", e2)
-			}
-			resQueue <- res
-		}
-		return
-	}
-	new_auth_token := r.Header.Get("Update-Client-Auth")
-	if new_auth_token != "" && apikey != new_auth_token {
-		psp.VolatileData["apikey"] = new_auth_token
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = push.NewPushServiceProviderUpdate(psp)
-		resQueue <- res
-	}
-
-	switch r.StatusCode {
-	case 503:
-		fallthrough
-	case 500:
-		/* TODO extract the retry after field */
-		after := 0 * time.Second
-		for _, dp := range dpList {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-			res.Destination = dp
-			err := push.NewRetryError(psp, dp, notif, after)
-			res.Err = err
-			resQueue <- res
-		}
-		return
-	case 401:
-		err := push.NewBadPushServiceProvider(psp)
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = err
-		resQueue <- res
-		return
-	case 400:
-		err := push.NewBadNotification()
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = err
-		resQueue <- res
-		return
-	}
-
-	contents, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = push.NewErrorf("Failed to read FCM response: %v", err)
-		resQueue <- res
-		return
-	}
-
-	var result fcmResult
-	err = json.Unmarshal(contents, &result)
-
-	if err != nil {
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = push.NewErrorf("Failed to decode FCM response: %v", err)
-		resQueue <- res
-		return
-	}
-
-	for i, r := range result.Results {
-		if i >= len(dpList) {
-			break
-		}
-		dp := dpList[i]
-		if errmsg, ok := r["error"]; ok {
-			switch errmsg {
-			case "Unavailable":
-				after, _ := time.ParseDuration("2s")
-				res := new(push.PushResult)
-				res.Provider = psp
-				res.Content = notif
-				res.Destination = dp
-				res.Err = push.NewRetryError(psp, dp, notif, after)
-				resQueue <- res
-			case "NotRegistered":
-				res := new(push.PushResult)
-				res.Provider = psp
-				res.Err = push.NewUnsubscribeUpdate(psp, dp)
-				res.Content = notif
-				res.Destination = dp
-				resQueue <- res
-			case "InvalidRegistration":
-				res := new(push.PushResult)
-				res.Err = push.NewInvalidRegistrationUpdate(psp, dp)
-				res.Content = notif
-				res.Destination = dp
-				resQueue <- res
-			default:
-				res := new(push.PushResult)
-				res.Err = push.NewErrorf("FCMError: %v", errmsg)
-				res.Provider = psp
-				res.Content = notif
-				res.Destination = dp
-				resQueue <- res
-			}
-		}
-		if newregid, ok := r["registration_id"]; ok {
-			dp.VolatileData["regid"] = newregid
-			res := new(push.PushResult)
-			res.Err = push.NewDeliveryPointUpdate(dp)
-			res.Provider = psp
-			res.Content = notif
-			res.Destination = dp
-			resQueue <- res
-		}
-		if msgid, ok := r["message_id"]; ok {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-			res.Destination = dp
-			res.MsgId = fmt.Sprintf("%v:%v", psp.Name(), msgid)
-			resQueue <- res
-		}
-	}
-
-}
-
-func (self *fcmPushService) Push(psp *push.PushServiceProvider, dpQueue <-chan *push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
-
-	maxNrDst := 1000
-	dpList := make([]*push.DeliveryPoint, 0, maxNrDst)
-	for dp := range dpQueue {
-		if psp.PushServiceName() != dp.PushServiceName() || psp.PushServiceName() != self.Name() {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Destination = dp
-			res.Content = notif
-			res.Err = push.NewIncompatibleError()
-			resQueue <- res
-			continue
-		}
-		if _, ok := dp.VolatileData["regid"]; ok {
-			dpList = append(dpList, dp)
-		} else if regid, ok := dp.FixedData["regid"]; ok {
-			dp.VolatileData["regid"] = regid
-			dpList = append(dpList, dp)
-		} else {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Destination = dp
-			res.Content = notif
-			res.Err = push.NewBadDeliveryPoint(dp)
-			resQueue <- res
-			continue
-		}
-
-		if len(dpList) >= maxNrDst {
-			self.multicast(psp, dpList, resQueue, notif)
-			dpList = dpList[:0]
-		}
-	}
-	if len(dpList) > 0 {
-		self.multicast(psp, dpList, resQueue, notif)
-	}
-
-	close(resQueue)
-}
-
-func (self *fcmPushService) Preview(notif *push.Notification) ([]byte, push.PushError) {
-	return toFCMPayload(notif, []string{"placeholderRegId"})
-}
-
-func (self *fcmPushService) SetErrorReportChan(errChan chan<- push.PushError) {
-	return
 }

--- a/srv/fcm.go
+++ b/srv/fcm.go
@@ -1,0 +1,464 @@
+/*
+ * Copyright 2011-2013 Nan Deng
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ */
+
+package srv
+
+import (
+	"bytes"
+	"crypto/tls"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"net"
+	"net/http"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/uniqush/uniqush-push/push"
+)
+
+const (
+	fcmServiceURL string = "https://fcm.googleapis.com/fcm/send"
+)
+
+var _ HTTPClient = &http.Client{}
+
+type fcmPushService struct {
+	// There is only one Transport and one Client for connecting to fcm, shared by the set of PSPs with pushservicetype=fcm (whether or not this is using a sandbox)
+	client HTTPClient
+}
+
+var _ push.PushServiceType = &fcmPushService{}
+
+func newFCMPushService() *fcmPushService {
+	conf := &tls.Config{InsecureSkipVerify: false}
+	tr := &http.Transport{
+		TLSClientConfig:     conf,
+		TLSHandshakeTimeout: time.Second * 5,
+		// TODO: Make this configurable later on? The default of 2 is too low.
+		// goals: (1) new connections should not be opened and closed frequently, (2) we should not run out of sockets.
+		// This doesn't seem to need much tuning. The number of connections open at a given time seems to be less than 500, even when sending hundreds of pushes per second.
+		MaxIdleConnsPerHost: 500,
+	}
+	client := &http.Client{
+		Transport: tr,
+		Timeout:   time.Second * 10, // Add a timeout for all requests, in case of network issues.
+	}
+	return &fcmPushService{
+		client: client,
+	}
+}
+
+func InstallFCM() {
+	psm := push.GetPushServiceManager()
+	psm.RegisterPushServiceType(newFCMPushService())
+}
+
+func (g *fcmPushService) OverrideClient(client HTTPClient) {
+	g.client = client
+}
+
+func (p *fcmPushService) Finalize() {
+	if client, isClient := p.client.(*http.Client); isClient {
+		if transport, ok := client.Transport.(*http.Transport); ok {
+			transport.CloseIdleConnections()
+		}
+	}
+}
+
+func (p *fcmPushService) BuildPushServiceProviderFromMap(kv map[string]string,
+	psp *push.PushServiceProvider) error {
+	if service, ok := kv["service"]; ok && len(service) > 0 {
+		psp.FixedData["service"] = service
+	} else {
+		return errors.New("NoService")
+	}
+
+	if authtoken, ok := kv["apikey"]; ok && len(authtoken) > 0 {
+		psp.VolatileData["apikey"] = authtoken
+	} else {
+		return errors.New("NoAPIKey")
+	}
+
+	return nil
+}
+
+func (p *fcmPushService) BuildDeliveryPointFromMap(kv map[string]string,
+	dp *push.DeliveryPoint) error {
+	if service, ok := kv["service"]; ok && len(service) > 0 {
+		dp.FixedData["service"] = service
+	} else {
+		return errors.New("NoService")
+	}
+	if sub, ok := kv["subscriber"]; ok && len(sub) > 0 {
+		dp.FixedData["subscriber"] = sub
+	} else {
+		return errors.New("NoSubscriber")
+	}
+	if account, ok := kv["account"]; ok && len(account) > 0 {
+		dp.FixedData["account"] = account
+	}
+	if regid, ok := kv["regid"]; ok && len(regid) > 0 {
+		dp.FixedData["regid"] = regid
+	} else {
+		return errors.New("NoRegId")
+	}
+
+	return nil
+}
+
+func (p *fcmPushService) Name() string {
+	return "fcm"
+}
+
+type fcmData struct {
+	RegIDs         []string               `json:"registration_ids"`
+	CollapseKey    string                 `json:"collapse_key,omitempty"`
+	Data           map[string]interface{} `json:"data"` // For compatibility with other FCM platforms(e.g. iOS), should always be a map[string]string
+	DelayWhileIdle bool                   `json:"delay_while_idle,omitempty"`
+	TimeToLive     uint                   `json:"time_to_live,omitempty"`
+}
+
+func (d *fcmData) String() string {
+	ret, err := json.Marshal(d)
+	if err != nil {
+		return ""
+	}
+	return string(ret)
+}
+
+type fcmResult struct {
+	MulticastID  uint64              `json:"multicast_id"`
+	Success      uint                `json:"success"`
+	Failure      uint                `json:"failure"`
+	CanonicalIDs uint                `json:"canonical_ids"`
+	Results      []map[string]string `json:"results"`
+}
+
+// validateRawFCMData verifies that the user-provided JSON payload is a valid JSON object.
+func validateRawFCMData(payload string) (map[string]interface{}, push.PushError) {
+	var data map[string]interface{}
+	err := json.Unmarshal([]byte(payload), &data)
+	if data == nil {
+		return nil, push.NewBadNotificationWithDetails(fmt.Sprintf("Could not parse FCM data: %v", err))
+	}
+	return data, nil
+}
+
+// toFCMPayload converts the notification data to a JSON-encoded string to POST to FCM.
+func toFCMPayload(notif *push.Notification, regIds []string) ([]byte, push.PushError) {
+	postData := notif.Data
+	payload := new(fcmData)
+	payload.RegIDs = regIds
+
+	// TTL: default is one hour
+	payload.TimeToLive = 60 * 60
+	payload.DelayWhileIdle = false
+
+	if mgroup, ok := postData["msggroup"]; ok {
+		payload.CollapseKey = mgroup
+	} else {
+		payload.CollapseKey = ""
+	}
+
+	if ttlStr, ok := postData["ttl"]; ok {
+		ttl, err := strconv.ParseUint(ttlStr, 10, 32)
+		if err == nil {
+			payload.TimeToLive = uint(ttl)
+		}
+	}
+
+	if rawData, ok := postData["uniqush.payload.fcm"]; ok {
+		// Could add uniqush.notification.fcm as another optional payload, to conform to FCM spec: https://developers.google.com/cloud-messaging/http-server-ref#send-downstream
+		data, err := validateRawFCMData(rawData)
+		if err != nil {
+			return nil, err
+		}
+		payload.Data = data
+	} else {
+		nr_elem := len(postData)
+		payload.Data = make(map[string]interface{}, nr_elem)
+
+		for k, v := range postData {
+			if strings.HasPrefix(k, "uniqush.") { // The "uniqush." keys are reserved for uniqush use.
+				continue
+			}
+			switch k {
+			case "msggroup", "ttl":
+				continue
+			default:
+				payload.Data[k] = v
+			}
+		}
+	}
+
+	jpayload, e0 := json.Marshal(payload)
+	if e0 != nil {
+		return nil, push.NewErrorf("Error converting payload to JSON: %v", e0)
+	}
+	return jpayload, nil
+
+}
+
+func (self *fcmPushService) multicast(psp *push.PushServiceProvider, dpList []*push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
+	if len(dpList) == 0 {
+		return
+	}
+
+	regIds := make([]string, 0, len(dpList))
+
+	for _, dp := range dpList {
+		regIds = append(regIds, dp.VolatileData["regid"])
+	}
+
+	jpayload, e0 := toFCMPayload(notif, regIds)
+
+	if e0 != nil {
+		for _, dp := range dpList {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Content = notif
+
+			res.Err = e0
+			res.Destination = dp
+			resQueue <- res
+		}
+		return
+	}
+
+	req, e1 := http.NewRequest("POST", fcmServiceURL, bytes.NewReader(jpayload))
+	if req != nil {
+		defer req.Body.Close()
+	}
+	if e1 != nil {
+		for _, dp := range dpList {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Content = notif
+
+			res.Err = push.NewErrorf("Error constructing HTTP request: %v", e1)
+			res.Destination = dp
+			resQueue <- res
+		}
+		return
+	}
+
+	apikey := psp.VolatileData["apikey"]
+
+	req.Header.Set("Authorization", "key="+apikey)
+	req.Header.Set("Content-Type", "application/json")
+
+	// Perform a request, using a connection from the connection pool of a shared http.Client instance.
+	r, e2 := self.client.Do(req)
+	if r != nil {
+		defer r.Body.Close()
+	}
+	if e2 != nil {
+		for _, dp := range dpList {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Content = notif
+
+			res.Destination = dp
+			if err, ok := e2.(net.Error); ok {
+				// Temporary error. Try to recover
+				if err.Temporary() {
+					after := 3 * time.Second
+					res.Err = push.NewRetryErrorWithReason(psp, dp, notif, after, err)
+				}
+			} else if err, ok := e2.(*net.DNSError); ok {
+				// DNS error, try to recover it by retry
+				after := 3 * time.Second
+				res.Err = push.NewRetryErrorWithReason(psp, dp, notif, after, err)
+
+			} else {
+				res.Err = push.NewErrorf("Unrecoverable HTTP error sending to FCM: %v", e2)
+			}
+			resQueue <- res
+		}
+		return
+	}
+	new_auth_token := r.Header.Get("Update-Client-Auth")
+	if new_auth_token != "" && apikey != new_auth_token {
+		psp.VolatileData["apikey"] = new_auth_token
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = push.NewPushServiceProviderUpdate(psp)
+		resQueue <- res
+	}
+
+	switch r.StatusCode {
+	case 503:
+		fallthrough
+	case 500:
+		/* TODO extract the retry after field */
+		after := 0 * time.Second
+		for _, dp := range dpList {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Content = notif
+			res.Destination = dp
+			err := push.NewRetryError(psp, dp, notif, after)
+			res.Err = err
+			resQueue <- res
+		}
+		return
+	case 401:
+		err := push.NewBadPushServiceProvider(psp)
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = err
+		resQueue <- res
+		return
+	case 400:
+		err := push.NewBadNotification()
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = err
+		resQueue <- res
+		return
+	}
+
+	contents, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = push.NewErrorf("Failed to read FCM response: %v", err)
+		resQueue <- res
+		return
+	}
+
+	var result fcmResult
+	err = json.Unmarshal(contents, &result)
+
+	if err != nil {
+		res := new(push.PushResult)
+		res.Provider = psp
+		res.Content = notif
+		res.Err = push.NewErrorf("Failed to decode FCM response: %v", err)
+		resQueue <- res
+		return
+	}
+
+	for i, r := range result.Results {
+		if i >= len(dpList) {
+			break
+		}
+		dp := dpList[i]
+		if errmsg, ok := r["error"]; ok {
+			switch errmsg {
+			case "Unavailable":
+				after, _ := time.ParseDuration("2s")
+				res := new(push.PushResult)
+				res.Provider = psp
+				res.Content = notif
+				res.Destination = dp
+				res.Err = push.NewRetryError(psp, dp, notif, after)
+				resQueue <- res
+			case "NotRegistered":
+				res := new(push.PushResult)
+				res.Provider = psp
+				res.Err = push.NewUnsubscribeUpdate(psp, dp)
+				res.Content = notif
+				res.Destination = dp
+				resQueue <- res
+			case "InvalidRegistration":
+				res := new(push.PushResult)
+				res.Err = push.NewInvalidRegistrationUpdate(psp, dp)
+				res.Content = notif
+				res.Destination = dp
+				resQueue <- res
+			default:
+				res := new(push.PushResult)
+				res.Err = push.NewErrorf("FCMError: %v", errmsg)
+				res.Provider = psp
+				res.Content = notif
+				res.Destination = dp
+				resQueue <- res
+			}
+		}
+		if newregid, ok := r["registration_id"]; ok {
+			dp.VolatileData["regid"] = newregid
+			res := new(push.PushResult)
+			res.Err = push.NewDeliveryPointUpdate(dp)
+			res.Provider = psp
+			res.Content = notif
+			res.Destination = dp
+			resQueue <- res
+		}
+		if msgid, ok := r["message_id"]; ok {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Content = notif
+			res.Destination = dp
+			res.MsgId = fmt.Sprintf("%v:%v", psp.Name(), msgid)
+			resQueue <- res
+		}
+	}
+
+}
+
+func (self *fcmPushService) Push(psp *push.PushServiceProvider, dpQueue <-chan *push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
+
+	maxNrDst := 1000
+	dpList := make([]*push.DeliveryPoint, 0, maxNrDst)
+	for dp := range dpQueue {
+		if psp.PushServiceName() != dp.PushServiceName() || psp.PushServiceName() != self.Name() {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Destination = dp
+			res.Content = notif
+			res.Err = push.NewIncompatibleError()
+			resQueue <- res
+			continue
+		}
+		if _, ok := dp.VolatileData["regid"]; ok {
+			dpList = append(dpList, dp)
+		} else if regid, ok := dp.FixedData["regid"]; ok {
+			dp.VolatileData["regid"] = regid
+			dpList = append(dpList, dp)
+		} else {
+			res := new(push.PushResult)
+			res.Provider = psp
+			res.Destination = dp
+			res.Content = notif
+			res.Err = push.NewBadDeliveryPoint(dp)
+			resQueue <- res
+			continue
+		}
+
+		if len(dpList) >= maxNrDst {
+			self.multicast(psp, dpList, resQueue, notif)
+			dpList = dpList[:0]
+		}
+	}
+	if len(dpList) > 0 {
+		self.multicast(psp, dpList, resQueue, notif)
+	}
+
+	close(resQueue)
+}
+
+func (self *fcmPushService) SetErrorReportChan(errChan chan<- push.PushError) {
+	return
+}

--- a/srv/fcm.go
+++ b/srv/fcm.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011-2013 Nan Deng
+ * Copyright 2013-2017 Uniqush Contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/srv/fcm_push_service_test.go
+++ b/srv/fcm_push_service_test.go
@@ -15,52 +15,52 @@ import (
 )
 
 const (
-	MOCK_API_KEY    = "mockapikey"
-	MOCK_PROJECT_ID = "mockprojectid"
-	MOCK_SERVICE    = "mockservice"
+	FCM_MOCK_API_KEY    = "mockapikey"
+	FCM_MOCK_PROJECT_ID = "mockprojectid"
+	FCM_MOCK_SERVICE    = "mockservice"
 )
 
-type mockHTTPClient struct {
+type fcmMockHTTPClient struct {
 	status       int
 	responseBody []byte
 	headers      map[string]string
 	requestError error
 	// Mocks for responses given json encoded request, TODO write expectations.
-	// mockResponses map[string]string
-	performed []*mockResponse
+	// fcmMockResponses map[string]string
+	performed []*fcmMockResponse
 }
 
-type mockResponse struct {
+type fcmMockResponse struct {
 	impl    *bytes.Reader
 	closed  bool
 	request *http.Request
 }
 
-var _ io.ReadCloser = &mockResponse{}
+var _ io.ReadCloser = &fcmMockResponse{}
 
-func newMockResponse(contents []byte, request *http.Request) *mockResponse {
-	return &mockResponse{
+func fcmNewMockResponse(contents []byte, request *http.Request) *fcmMockResponse {
+	return &fcmMockResponse{
 		impl:    bytes.NewReader(contents),
 		closed:  false,
 		request: request,
 	}
 }
 
-func (r *mockResponse) Read(p []byte) (n int, err error) {
+func (r *fcmMockResponse) Read(p []byte) (n int, err error) {
 	return r.impl.Read(p)
 }
 
-func (r *mockResponse) Close() error {
+func (r *fcmMockResponse) Close() error {
 	r.closed = true
 	return nil
 }
 
-func (c *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
+func (c *fcmMockHTTPClient) Do(request *http.Request) (*http.Response, error) {
 	h := http.Header{}
 	for k, v := range c.headers {
 		h.Set(k, v)
 	}
-	body := newMockResponse(c.responseBody, request)
+	body := fcmNewMockResponse(c.responseBody, request)
 	result := &http.Response{
 		StatusCode: c.status,
 		Body:       body,
@@ -70,10 +70,10 @@ func (c *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
 	return result, c.requestError
 }
 
-var _ FCMHTTPClient = &mockHTTPClient{}
+var _ FCMHTTPClient = &fcmMockHTTPClient{}
 
-func commonFCMMocks(responseCode int, responseBody []byte, headers map[string]string, requestError error) (*push.PushServiceProvider, *mockHTTPClient, *fcmPushService, chan push.PushError) {
-	client := &mockHTTPClient{
+func commonFCMMocks(responseCode int, responseBody []byte, headers map[string]string, requestError error) (*push.PushServiceProvider, *fcmMockHTTPClient, *fcmPushService, chan push.PushError) {
+	client := &fcmMockHTTPClient{
 		status:       responseCode,
 		responseBody: responseBody,
 		headers:      headers,
@@ -91,10 +91,10 @@ func commonFCMMocks(responseCode int, responseBody []byte, headers map[string]st
 
 	psp, err := psm.BuildPushServiceProviderFromMap(map[string]string{
 		"pushservicetype": service.Name(),
-		"service":         MOCK_SERVICE,
+		"service":         FCM_MOCK_SERVICE,
 		"subscriber":      "mocksubscriber",
-		"apikey":          MOCK_API_KEY,
-		"projectid":       MOCK_PROJECT_ID,
+		"apikey":          FCM_MOCK_API_KEY,
+		"projectid":       FCM_MOCK_PROJECT_ID,
 	})
 
 	if psp == nil {
@@ -106,13 +106,13 @@ func commonFCMMocks(responseCode int, responseBody []byte, headers map[string]st
 	return psp, client, service, errChan
 }
 
-func asyncCreateDPQueue(wg *sync.WaitGroup, dpQueue chan<- *push.DeliveryPoint, regId, subscriber string) {
+func fcmAsyncCreateDPQueue(wg *sync.WaitGroup, dpQueue chan<- *push.DeliveryPoint, regId, subscriber string) {
 	psm := push.GetPushServiceManager()
 	mockDeliveryPoint, err := psm.BuildDeliveryPointFromMap(map[string]string{
 		"regid":           regId,
 		"subscriber":      subscriber,
 		"pushservicetype": "fcm",
-		"service":         MOCK_SERVICE,
+		"service":         FCM_MOCK_SERVICE,
 	})
 	if err != nil {
 		panic(err)
@@ -122,13 +122,13 @@ func asyncCreateDPQueue(wg *sync.WaitGroup, dpQueue chan<- *push.DeliveryPoint, 
 	wg.Done()
 }
 
-func asyncPush(wg *sync.WaitGroup, service *fcmPushService, psp *push.PushServiceProvider, dpQueue <-chan *push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
+func fcmAsyncPush(wg *sync.WaitGroup, service *fcmPushService, psp *push.PushServiceProvider, dpQueue <-chan *push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
 	service.Push(psp, dpQueue, resQueue, notif)
 	wg.Done()
 }
 
-// TestPushSingle tests the ability to send a single push without error, and shut down cleanly.
-func TestPushSingle(t *testing.T) {
+// fcmTestPushSingle tests the ability to send a single push without error, and shut down cleanly.
+func fcmTestPushSingle(t *testing.T) {
 	expectedRegId := "mockregid"
 	notif := push.NewEmptyNotification()
 	expectedPayload := `{"message":{"aPushType":{"foo":"bar","other":"value"},"fcm":{},"others":{"type":"aPushType"}}}`
@@ -136,13 +136,13 @@ func TestPushSingle(t *testing.T) {
 		"uniqush.payload.fcm": expectedPayload,
 	}
 	mockHTTPResponse := []byte(`{"multicast_id":777,"canonical_ids":1,"success":1,"failure":0,"results":[{"message_id":"UID12345"}]}`)
-	psp, mockHTTPClient, service, errChan := commonFCMMocks(200, mockHTTPResponse, map[string]string{}, nil)
+	psp, fcmMockHTTPClient, service, errChan := commonFCMMocks(200, mockHTTPResponse, map[string]string{}, nil)
 	dpQueue := make(chan *push.DeliveryPoint)
 	resQueue := make(chan *push.PushResult)
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
-	go asyncCreateDPQueue(wg, dpQueue, expectedRegId, "unusedsubscriber1")
-	go asyncPush(wg, service, psp, dpQueue, resQueue, notif)
+	go fcmAsyncCreateDPQueue(wg, dpQueue, expectedRegId, "unusedsubscriber1")
+	go fcmAsyncPush(wg, service, psp, dpQueue, resQueue, notif)
 	resCount := 0
 	for res := range resQueue {
 		if res == nil {
@@ -165,19 +165,19 @@ func TestPushSingle(t *testing.T) {
 	if numErrs := len(errChan); numErrs > 0 {
 		t.Errorf("Unexpected number of errors: want none, got %d", numErrs)
 	}
-	if len(mockHTTPClient.performed) != 1 {
-		t.Errorf("Unexpected number of http calls: want 1, got %#v", mockHTTPClient.performed)
+	if len(fcmMockHTTPClient.performed) != 1 {
+		t.Errorf("Unexpected number of http calls: want 1, got %#v", fcmMockHTTPClient.performed)
 	}
-	mockResponse := mockHTTPClient.performed[0]
-	if !mockResponse.closed {
+	fcmMockResponse := fcmMockHTTPClient.performed[0]
+	if !fcmMockResponse.closed {
 		t.Error("Expected the mock response body to be closed")
 	}
 
-	assertExpectedFCMRequest(t, mockResponse.request, expectedRegId, expectedPayload)
+	assertExpectedFCMRequest(t, fcmMockResponse.request, expectedRegId, expectedPayload)
 }
 
-// TestPushSingleError tests the ability to send a single push with an error error, and shut down cleanly.
-func TestPushSingleError(t *testing.T) {
+// fcmTestPushSingleError tests the ability to send a single push with an error error, and shut down cleanly.
+func fcmTestPushSingleError(t *testing.T) {
 	expectedRegId := "mockregid"
 	notif := push.NewEmptyNotification()
 	expectedPayload := `{"message":{"aPushType":{"foo":"bar","other":"value"},"fcm":{},"others":{"type":"aPushType"}}}`
@@ -185,13 +185,13 @@ func TestPushSingleError(t *testing.T) {
 		"uniqush.payload.fcm": expectedPayload,
 	}
 	mockHTTPResponse := []byte(`HTTP/401 error mock response`)
-	psp, mockHTTPClient, service, errChan := commonFCMMocks(401, mockHTTPResponse, map[string]string{}, nil)
+	psp, fcmMockHTTPClient, service, errChan := commonFCMMocks(401, mockHTTPResponse, map[string]string{}, nil)
 	dpQueue := make(chan *push.DeliveryPoint)
 	resQueue := make(chan *push.PushResult)
 	wg := new(sync.WaitGroup)
 	wg.Add(2)
-	go asyncCreateDPQueue(wg, dpQueue, expectedRegId, "unusedsubscriber1")
-	go asyncPush(wg, service, psp, dpQueue, resQueue, notif)
+	go fcmAsyncCreateDPQueue(wg, dpQueue, expectedRegId, "unusedsubscriber1")
+	go fcmAsyncPush(wg, service, psp, dpQueue, resQueue, notif)
 	resCount := 0
 	for res := range resQueue {
 		if res.Err == nil {
@@ -218,15 +218,15 @@ func TestPushSingleError(t *testing.T) {
 	if numErrs := len(errChan); numErrs > 0 {
 		t.Errorf("Unexpected number of errors: want none, got %d", numErrs)
 	}
-	if len(mockHTTPClient.performed) != 1 {
-		t.Errorf("Unexpected number of http calls: want 1, got %#v", mockHTTPClient.performed)
+	if len(fcmMockHTTPClient.performed) != 1 {
+		t.Errorf("Unexpected number of http calls: want 1, got %#v", fcmMockHTTPClient.performed)
 	}
-	mockResponse := mockHTTPClient.performed[0]
-	if !mockResponse.closed {
+	fcmMockResponse := fcmMockHTTPClient.performed[0]
+	if !fcmMockResponse.closed {
 		t.Error("Expected the mock response body to be closed")
 	}
 
-	assertExpectedFCMRequest(t, mockResponse.request, expectedRegId, expectedPayload)
+	assertExpectedFCMRequest(t, fcmMockResponse.request, expectedRegId, expectedPayload)
 }
 
 // Helper function, because golang json serialization has an unpredictable order.
@@ -257,7 +257,7 @@ func assertExpectedFCMRequest(t *testing.T, request *http.Request, expectedRegId
 	}
 
 	actualAuth := request.Header.Get("Authorization")
-	expectedAuth := "key=" + MOCK_API_KEY
+	expectedAuth := "key=" + FCM_MOCK_API_KEY
 	if actualAuth != expectedAuth {
 		t.Errorf("Expected auth %q, got %q", expectedAuth, actualAuth)
 	}

--- a/srv/fcm_push_service_test.go
+++ b/srv/fcm_push_service_test.go
@@ -70,16 +70,16 @@ func (c *mockHTTPClient) Do(request *http.Request) (*http.Response, error) {
 	return result, c.requestError
 }
 
-var _ GCMHTTPClient = &mockHTTPClient{}
+var _ FCMHTTPClient = &mockHTTPClient{}
 
-func commonGCMMocks(responseCode int, responseBody []byte, headers map[string]string, requestError error) (*push.PushServiceProvider, *mockHTTPClient, *gcmPushService, chan push.PushError) {
+func commonFCMMocks(responseCode int, responseBody []byte, headers map[string]string, requestError error) (*push.PushServiceProvider, *mockHTTPClient, *fcmPushService, chan push.PushError) {
 	client := &mockHTTPClient{
 		status:       responseCode,
 		responseBody: responseBody,
 		headers:      headers,
 		requestError: requestError,
 	}
-	service := newGCMPushService()
+	service := newFCMPushService()
 	service.OverrideClient(client)
 
 	// Overwrite the APNS service.
@@ -111,7 +111,7 @@ func asyncCreateDPQueue(wg *sync.WaitGroup, dpQueue chan<- *push.DeliveryPoint, 
 	mockDeliveryPoint, err := psm.BuildDeliveryPointFromMap(map[string]string{
 		"regid":           regId,
 		"subscriber":      subscriber,
-		"pushservicetype": "gcm",
+		"pushservicetype": "fcm",
 		"service":         MOCK_SERVICE,
 	})
 	if err != nil {
@@ -122,7 +122,7 @@ func asyncCreateDPQueue(wg *sync.WaitGroup, dpQueue chan<- *push.DeliveryPoint, 
 	wg.Done()
 }
 
-func asyncPush(wg *sync.WaitGroup, service *gcmPushService, psp *push.PushServiceProvider, dpQueue <-chan *push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
+func asyncPush(wg *sync.WaitGroup, service *fcmPushService, psp *push.PushServiceProvider, dpQueue <-chan *push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
 	service.Push(psp, dpQueue, resQueue, notif)
 	wg.Done()
 }
@@ -131,12 +131,12 @@ func asyncPush(wg *sync.WaitGroup, service *gcmPushService, psp *push.PushServic
 func TestPushSingle(t *testing.T) {
 	expectedRegId := "mockregid"
 	notif := push.NewEmptyNotification()
-	expectedPayload := `{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}}`
+	expectedPayload := `{"message":{"aPushType":{"foo":"bar","other":"value"},"fcm":{},"others":{"type":"aPushType"}}}`
 	notif.Data = map[string]string{
-		"uniqush.payload.gcm": expectedPayload,
+		"uniqush.payload.fcm": expectedPayload,
 	}
 	mockHTTPResponse := []byte(`{"multicast_id":777,"canonical_ids":1,"success":1,"failure":0,"results":[{"message_id":"UID12345"}]}`)
-	psp, mockHTTPClient, service, errChan := commonGCMMocks(200, mockHTTPResponse, map[string]string{}, nil)
+	psp, mockHTTPClient, service, errChan := commonFCMMocks(200, mockHTTPResponse, map[string]string{}, nil)
 	dpQueue := make(chan *push.DeliveryPoint)
 	resQueue := make(chan *push.PushResult)
 	wg := new(sync.WaitGroup)
@@ -173,19 +173,19 @@ func TestPushSingle(t *testing.T) {
 		t.Error("Expected the mock response body to be closed")
 	}
 
-	assertExpectedGCMRequest(t, mockResponse.request, expectedRegId, expectedPayload)
+	assertExpectedFCMRequest(t, mockResponse.request, expectedRegId, expectedPayload)
 }
 
 // TestPushSingleError tests the ability to send a single push with an error error, and shut down cleanly.
 func TestPushSingleError(t *testing.T) {
 	expectedRegId := "mockregid"
 	notif := push.NewEmptyNotification()
-	expectedPayload := `{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}}`
+	expectedPayload := `{"message":{"aPushType":{"foo":"bar","other":"value"},"fcm":{},"others":{"type":"aPushType"}}}`
 	notif.Data = map[string]string{
-		"uniqush.payload.gcm": expectedPayload,
+		"uniqush.payload.fcm": expectedPayload,
 	}
 	mockHTTPResponse := []byte(`HTTP/401 error mock response`)
-	psp, mockHTTPClient, service, errChan := commonGCMMocks(401, mockHTTPResponse, map[string]string{}, nil)
+	psp, mockHTTPClient, service, errChan := commonFCMMocks(401, mockHTTPResponse, map[string]string{}, nil)
 	dpQueue := make(chan *push.DeliveryPoint)
 	resQueue := make(chan *push.PushResult)
 	wg := new(sync.WaitGroup)
@@ -226,7 +226,7 @@ func TestPushSingleError(t *testing.T) {
 		t.Error("Expected the mock response body to be closed")
 	}
 
-	assertExpectedGCMRequest(t, mockResponse.request, expectedRegId, expectedPayload)
+	assertExpectedFCMRequest(t, mockResponse.request, expectedRegId, expectedPayload)
 }
 
 // Helper function, because golang json serialization has an unpredictable order.
@@ -245,10 +245,10 @@ func expectJSONIsEquivalent(t *testing.T, expected []byte, actual []byte) {
 	}
 }
 
-func assertExpectedGCMRequest(t *testing.T, request *http.Request, expectedRegId, expectedPayload string) {
+func assertExpectedFCMRequest(t *testing.T, request *http.Request, expectedRegId, expectedPayload string) {
 	actualURL := request.URL.String()
-	if actualURL != gcmServiceURL {
-		t.Errorf("Expected URL %q, got %q", gcmServiceURL, actualURL)
+	if actualURL != fcmServiceURL {
+		t.Errorf("Expected URL %q, got %q", fcmServiceURL, actualURL)
 	}
 	actualContentType := request.Header.Get("Content-Type")
 	expectedContentType := "application/json"
@@ -270,14 +270,14 @@ func assertExpectedGCMRequest(t *testing.T, request *http.Request, expectedRegId
 	expectJSONIsEquivalent(t, []byte(expectedBody), actualBodyBytes)
 }
 
-// Overlaps with TestToGCMPayload, since Preview just calls toGCMPayload.
+// Overlaps with TestToFCMPayload, since Preview just calls toFCMPayload.
 func TestPreviewWithCommonParameters(t *testing.T) {
 	postData := map[string]string{
 		"msggroup":  "somegroup",
 		"other":     "value",
 		"other.foo": "bar",
 		"ttl":       "5",
-		// GCM module should ignore anything it doesn't recognize begining with "uniqush.", those are reserved.
+		// FCM module should ignore anything it doesn't recognize begining with "uniqush.", those are reserved.
 		"uniqush.payload.apns": "{}",
 		"uniqush.foo":          "foo",
 	}
@@ -286,7 +286,7 @@ func TestPreviewWithCommonParameters(t *testing.T) {
 	notif := push.NewEmptyNotification()
 	notif.Data = postData
 
-	_, _, service, _ := commonGCMMocks(200, []byte("unused"), map[string]string{}, nil)
+	_, _, service, _ := commonFCMMocks(200, []byte("unused"), map[string]string{}, nil)
 	defer service.Finalize()
 
 	payload, err := service.Preview(notif)

--- a/srv/fcm_push_service_test.go
+++ b/srv/fcm_push_service_test.go
@@ -231,7 +231,7 @@ func fcmTestPushSingleError(t *testing.T) {
 
 // Helper function, because golang json serialization has an unpredictable order.
 // Uses reflect.DeepEqual.
-func expectJSONIsEquivalent(t *testing.T, expected []byte, actual []byte) {
+func fcmExpectJSONIsEquivalent(t *testing.T, expected []byte, actual []byte) {
 	var expectedObj map[string]interface{}
 	var actualObj map[string]interface{}
 	if err := json.Unmarshal(expected, &expectedObj); err != nil {
@@ -267,11 +267,11 @@ func assertExpectedFCMRequest(t *testing.T, request *http.Request, expectedRegId
 		t.Fatalf("Unexpected error reading body: %v", err)
 	}
 	expectedBody := fmt.Sprintf(`{"registration_ids":[%q],"data":%s,"time_to_live":3600}`, expectedRegId, expectedPayload)
-	expectJSONIsEquivalent(t, []byte(expectedBody), actualBodyBytes)
+	fcmExpectJSONIsEquivalent(t, []byte(expectedBody), actualBodyBytes)
 }
 
 // Overlaps with TestToFCMPayload, since Preview just calls toFCMPayload.
-func TestPreviewWithCommonParameters(t *testing.T) {
+func FcmTestPreviewWithCommonParameters(t *testing.T) {
 	postData := map[string]string{
 		"msggroup":  "somegroup",
 		"other":     "value",

--- a/srv/fcm_test.go
+++ b/srv/fcm_test.go
@@ -10,7 +10,10 @@ import (
 func testToFCMPayload(t *testing.T, postData map[string]string, regIds []string, expectedPayload string) {
 	notif := push.NewEmptyNotification()
 	notif.Data = postData
-	payload, err := toFCMPayload(notif, regIds)
+	// Create a push service, just for the sake of realistically testing building payloads
+	stubPushService := newFCMPushService()
+	defer stubPushService.Finalize()
+	payload, err := stubPushService.ToCMPayload(notif, regIds)
 	if err != nil {
 		t.Fatalf("Encountered error %v\n", err)
 	}

--- a/srv/fcm_test.go
+++ b/srv/fcm_test.go
@@ -1,0 +1,68 @@
+package srv
+
+import (
+	"testing"
+)
+import (
+	"github.com/uniqush/uniqush-push/push"
+)
+
+func testToFCMPayload(t *testing.T, postData map[string]string, regIds []string, expectedPayload string) {
+	notif := push.NewEmptyNotification()
+	notif.Data = postData
+	payload, err := toFCMPayload(notif, regIds)
+	if err != nil {
+		t.Fatalf("Encountered error %v\n", err)
+	}
+	if string(payload) != expectedPayload {
+		t.Errorf("Expected %s, got %s", expectedPayload, string(payload))
+	}
+}
+
+func TestToFCMPayloadWithRawPayload(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":            "somegroup",
+		"uniqush.payload.fcm": `{"message":{"key": {},"x":"y"},"other":{}}`,
+		"foo": "bar",
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"message":{"key":{},"x":"y"},"other":{}},"time_to_live":3600}`
+	testToFCMPayload(t, postData, regIds, expectedPayload)
+}
+
+func TestToFCMPayloadWithCommonParameters(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":  "somegroup",
+		"other":     "value",
+		"other.foo": "bar",
+		"ttl":       "5",
+		// FCM module should ignore anything it doesn't recognize begining with "uniqush.", those are reserved.
+		"uniqush.payload.apns": "{}",
+		"uniqush.foo":          "foo",
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"other":"value","other.foo":"bar"},"time_to_live":5}`
+	testToFCMPayload(t, postData, regIds, expectedPayload)
+}
+
+// Test that it will be encoded properly if uniqush.payload.fcm is provided instead of uniqush.payload
+func TestToFCMPayloadNewWay(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":            "somegroup",
+		"uniqush.payload.fcm": `{"message":{"aPushType":{"foo":"bar","other":"value"},"fcm":{},"others":{"type":"aPushType"}}}`,
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"message":{"aPushType":{"foo":"bar","other":"value"},"fcm":{},"others":{"type":"aPushType"}}},"time_to_live":3600}`
+	testToFCMPayload(t, postData, regIds, expectedPayload)
+}
+
+// Test that the push type isn't used as a fallback collapse key or anything else.
+func TestToFCMPayloadUsesMsggroupForCollapseKey(t *testing.T) {
+	postData := map[string]string{
+		"uniqush.payload.fcm": `{"message":{"aPushType":{"foo":"bar","other":"value"},"fcm":{},"others":{"type":"aPushType"}}}`,
+		"msggroup":            "AMsgGroup",
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"AMsgGroup","data":{"message":{"aPushType":{"foo":"bar","other":"value"},"fcm":{},"others":{"type":"aPushType"}}},"time_to_live":3600}`
+	testToFCMPayload(t, postData, regIds, expectedPayload)
+}

--- a/srv/gcm.go
+++ b/srv/gcm.go
@@ -37,16 +37,16 @@ const (
 	gcmServiceURL string = "https://android.googleapis.com/gcm/send"
 )
 
-// HTTPClient is a mockable interface for the parts of http.Client used by the GCM module.
-type HTTPClient interface {
+// GCMHTTPClient is a mockable interface for the parts of http.Client used by the GCM module.
+type GCMHTTPClient interface {
 	Do(*http.Request) (*http.Response, error)
 }
 
-var _ HTTPClient = &http.Client{}
+var _ GCMHTTPClient = &http.Client{}
 
 type gcmPushService struct {
 	// There is only one Transport and one Client for connecting to gcm, shared by the set of PSPs with pushservicetype=gcm (whether or not this is using a sandbox)
-	client HTTPClient
+	client GCMHTTPClient
 }
 
 var _ push.PushServiceType = &gcmPushService{}
@@ -75,7 +75,7 @@ func InstallGCM() {
 	psm.RegisterPushServiceType(newGCMPushService())
 }
 
-func (g *gcmPushService) OverrideClient(client HTTPClient) {
+func (g *gcmPushService) OverrideClient(client GCMHTTPClient) {
 	g.client = client
 }
 

--- a/srv/gcm.go
+++ b/srv/gcm.go
@@ -13,78 +13,47 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
+
+ * This contains cloud messaging code specific to GCM.
+ * Implementation details common to GCM and FCM are kept in srv/cloud_messaging
  */
 
 package srv
 
 import (
-	"bytes"
-	"crypto/tls"
-	"encoding/json"
 	"errors"
-	"fmt"
-	"io/ioutil"
-	"net"
-	"net/http"
-	"strconv"
-	"strings"
-	"time"
 
 	"github.com/uniqush/uniqush-push/push"
+	cm "github.com/uniqush/uniqush-push/srv/cloud_messaging"
 )
 
 const (
+	// GCM endpoint
 	gcmServiceURL string = "https://android.googleapis.com/gcm/send"
+	// payload key to extract from push requests to uniqush
+	gcmRawPayloadKey = "uniqush.payload.gcm"
+	// acronym for log messages
+	gcmAcronym = "GCM"
+	// push service type(name), for requests to uniqush
+	gcmPushServiceName = "gcm"
 )
-
-// GCMHTTPClient is a mockable interface for the parts of http.Client used by the GCM module.
-type GCMHTTPClient interface {
-	Do(*http.Request) (*http.Response, error)
-}
-
-var _ GCMHTTPClient = &http.Client{}
 
 type gcmPushService struct {
 	// There is only one Transport and one Client for connecting to gcm, shared by the set of PSPs with pushservicetype=gcm (whether or not this is using a sandbox)
-	client GCMHTTPClient
+	cm.PushServiceBase
 }
 
 var _ push.PushServiceType = &gcmPushService{}
 
 func newGCMPushService() *gcmPushService {
-	conf := &tls.Config{InsecureSkipVerify: false}
-	tr := &http.Transport{
-		TLSClientConfig:     conf,
-		TLSHandshakeTimeout: time.Second * 5,
-		// TODO: Make this configurable later on? The default of 2 is too low.
-		// goals: (1) new connections should not be opened and closed frequently, (2) we should not run out of sockets.
-		// This doesn't seem to need much tuning. The number of connections open at a given time seems to be less than 500, even when sending hundreds of pushes per second.
-		MaxIdleConnsPerHost: 500,
-	}
-	client := &http.Client{
-		Transport: tr,
-		Timeout:   time.Second * 10, // Add a timeout for all requests, in case of network issues.
-	}
 	return &gcmPushService{
-		client: client,
+		PushServiceBase: cm.MakePushServiceBase(gcmAcronym, gcmRawPayloadKey, gcmServiceURL, gcmPushServiceName),
 	}
 }
 
 func InstallGCM() {
 	psm := push.GetPushServiceManager()
 	psm.RegisterPushServiceType(newGCMPushService())
-}
-
-func (g *gcmPushService) OverrideClient(client GCMHTTPClient) {
-	g.client = client
-}
-
-func (p *gcmPushService) Finalize() {
-	if client, isClient := p.client.(*http.Client); isClient {
-		if transport, ok := client.Transport.(*http.Transport); ok {
-			transport.CloseIdleConnections()
-		}
-	}
 }
 
 func (p *gcmPushService) BuildPushServiceProviderFromMap(kv map[string]string,
@@ -110,370 +79,6 @@ func (p *gcmPushService) BuildPushServiceProviderFromMap(kv map[string]string,
 	return nil
 }
 
-func (p *gcmPushService) BuildDeliveryPointFromMap(kv map[string]string,
-	dp *push.DeliveryPoint) error {
-	if service, ok := kv["service"]; ok && len(service) > 0 {
-		dp.FixedData["service"] = service
-	} else {
-		return errors.New("NoService")
-	}
-	if sub, ok := kv["subscriber"]; ok && len(sub) > 0 {
-		dp.FixedData["subscriber"] = sub
-	} else {
-		return errors.New("NoSubscriber")
-	}
-	if account, ok := kv["account"]; ok && len(account) > 0 {
-		dp.FixedData["account"] = account
-	}
-	if regid, ok := kv["regid"]; ok && len(regid) > 0 {
-		dp.FixedData["regid"] = regid
-	} else {
-		return errors.New("NoRegId")
-	}
-
-	return nil
-}
-
 func (p *gcmPushService) Name() string {
 	return "gcm"
-}
-
-type gcmData struct {
-	RegIDs         []string               `json:"registration_ids"`
-	CollapseKey    string                 `json:"collapse_key,omitempty"`
-	Data           map[string]interface{} `json:"data"` // For compatibility with other GCM platforms(e.g. iOS), should always be a map[string]string
-	DelayWhileIdle bool                   `json:"delay_while_idle,omitempty"`
-	TimeToLive     uint                   `json:"time_to_live,omitempty"`
-}
-
-func (d *gcmData) String() string {
-	ret, err := json.Marshal(d)
-	if err != nil {
-		return ""
-	}
-	return string(ret)
-}
-
-type gcmResult struct {
-	MulticastID  uint64              `json:"multicast_id"`
-	Success      uint                `json:"success"`
-	Failure      uint                `json:"failure"`
-	CanonicalIDs uint                `json:"canonical_ids"`
-	Results      []map[string]string `json:"results"`
-}
-
-// validateRawGCMData verifies that the user-provided JSON payload is a valid JSON object.
-func validateRawGCMData(payload string) (map[string]interface{}, push.PushError) {
-	var data map[string]interface{}
-	err := json.Unmarshal([]byte(payload), &data)
-	if data == nil {
-		return nil, push.NewBadNotificationWithDetails(fmt.Sprintf("Could not parse GCM data: %v", err))
-	}
-	return data, nil
-}
-
-// toGCMPayload converts the notification data to a JSON-encoded string to POST to GCM.
-func toGCMPayload(notif *push.Notification, regIds []string) ([]byte, push.PushError) {
-	postData := notif.Data
-	payload := new(gcmData)
-	payload.RegIDs = regIds
-
-	// TTL: default is one hour
-	payload.TimeToLive = 60 * 60
-	payload.DelayWhileIdle = false
-
-	if mgroup, ok := postData["msggroup"]; ok {
-		payload.CollapseKey = mgroup
-	} else {
-		payload.CollapseKey = ""
-	}
-
-	if ttlStr, ok := postData["ttl"]; ok {
-		ttl, err := strconv.ParseUint(ttlStr, 10, 32)
-		if err == nil {
-			payload.TimeToLive = uint(ttl)
-		}
-	}
-
-	if rawData, ok := postData["uniqush.payload.gcm"]; ok {
-		// Could add uniqush.notification.gcm as another optional payload, to conform to GCM spec: https://developers.google.com/cloud-messaging/http-server-ref#send-downstream
-		data, err := validateRawGCMData(rawData)
-		if err != nil {
-			return nil, err
-		}
-		payload.Data = data
-	} else {
-		nr_elem := len(postData)
-		payload.Data = make(map[string]interface{}, nr_elem)
-
-		for k, v := range postData {
-			if strings.HasPrefix(k, "uniqush.") { // The "uniqush." keys are reserved for uniqush use.
-				continue
-			}
-			switch k {
-			case "msggroup", "ttl":
-				continue
-			default:
-				payload.Data[k] = v
-			}
-		}
-	}
-
-	jpayload, e0 := json.Marshal(payload)
-	if e0 != nil {
-		return nil, push.NewErrorf("Error converting payload to JSON: %v", e0)
-	}
-	return jpayload, nil
-
-}
-
-func (self *gcmPushService) multicast(psp *push.PushServiceProvider, dpList []*push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
-	if len(dpList) == 0 {
-		return
-	}
-
-	regIds := make([]string, 0, len(dpList))
-
-	for _, dp := range dpList {
-		regIds = append(regIds, dp.VolatileData["regid"])
-	}
-
-	jpayload, e0 := toGCMPayload(notif, regIds)
-
-	if e0 != nil {
-		for _, dp := range dpList {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-
-			res.Err = e0
-			res.Destination = dp
-			resQueue <- res
-		}
-		return
-	}
-
-	req, e1 := http.NewRequest("POST", gcmServiceURL, bytes.NewReader(jpayload))
-	if req != nil {
-		defer req.Body.Close()
-	}
-	if e1 != nil {
-		for _, dp := range dpList {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-
-			res.Err = push.NewErrorf("Error constructing HTTP request: %v", e1)
-			res.Destination = dp
-			resQueue <- res
-		}
-		return
-	}
-
-	apikey := psp.VolatileData["apikey"]
-
-	req.Header.Set("Authorization", "key="+apikey)
-	req.Header.Set("Content-Type", "application/json")
-
-	// Perform a request, using a connection from the connection pool of a shared http.Client instance.
-	r, e2 := self.client.Do(req)
-	if r != nil {
-		defer r.Body.Close()
-	}
-	if e2 != nil {
-		for _, dp := range dpList {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-
-			res.Destination = dp
-			if err, ok := e2.(net.Error); ok {
-				// Temporary error. Try to recover
-				if err.Temporary() {
-					after := 3 * time.Second
-					res.Err = push.NewRetryErrorWithReason(psp, dp, notif, after, err)
-				}
-			} else if err, ok := e2.(*net.DNSError); ok {
-				// DNS error, try to recover it by retry
-				after := 3 * time.Second
-				res.Err = push.NewRetryErrorWithReason(psp, dp, notif, after, err)
-
-			} else {
-				res.Err = push.NewErrorf("Unrecoverable HTTP error sending to GCM: %v", e2)
-			}
-			resQueue <- res
-		}
-		return
-	}
-	new_auth_token := r.Header.Get("Update-Client-Auth")
-	if new_auth_token != "" && apikey != new_auth_token {
-		psp.VolatileData["apikey"] = new_auth_token
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = push.NewPushServiceProviderUpdate(psp)
-		resQueue <- res
-	}
-
-	switch r.StatusCode {
-	case 503:
-		fallthrough
-	case 500:
-		/* TODO extract the retry after field */
-		after := 0 * time.Second
-		for _, dp := range dpList {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-			res.Destination = dp
-			err := push.NewRetryError(psp, dp, notif, after)
-			res.Err = err
-			resQueue <- res
-		}
-		return
-	case 401:
-		err := push.NewBadPushServiceProvider(psp)
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = err
-		resQueue <- res
-		return
-	case 400:
-		err := push.NewBadNotification()
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = err
-		resQueue <- res
-		return
-	}
-
-	contents, err := ioutil.ReadAll(r.Body)
-	if err != nil {
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = push.NewErrorf("Failed to read GCM response: %v", err)
-		resQueue <- res
-		return
-	}
-
-	var result gcmResult
-	err = json.Unmarshal(contents, &result)
-
-	if err != nil {
-		res := new(push.PushResult)
-		res.Provider = psp
-		res.Content = notif
-		res.Err = push.NewErrorf("Failed to decode GCM response: %v", err)
-		resQueue <- res
-		return
-	}
-
-	for i, r := range result.Results {
-		if i >= len(dpList) {
-			break
-		}
-		dp := dpList[i]
-		if errmsg, ok := r["error"]; ok {
-			switch errmsg {
-			case "Unavailable":
-				after, _ := time.ParseDuration("2s")
-				res := new(push.PushResult)
-				res.Provider = psp
-				res.Content = notif
-				res.Destination = dp
-				res.Err = push.NewRetryError(psp, dp, notif, after)
-				resQueue <- res
-			case "NotRegistered":
-				res := new(push.PushResult)
-				res.Provider = psp
-				res.Err = push.NewUnsubscribeUpdate(psp, dp)
-				res.Content = notif
-				res.Destination = dp
-				resQueue <- res
-			case "InvalidRegistration":
-				res := new(push.PushResult)
-				res.Err = push.NewInvalidRegistrationUpdate(psp, dp)
-				res.Content = notif
-				res.Destination = dp
-				resQueue <- res
-			default:
-				res := new(push.PushResult)
-				res.Err = push.NewErrorf("GCMError: %v", errmsg)
-				res.Provider = psp
-				res.Content = notif
-				res.Destination = dp
-				resQueue <- res
-			}
-		}
-		if newregid, ok := r["registration_id"]; ok {
-			dp.VolatileData["regid"] = newregid
-			res := new(push.PushResult)
-			res.Err = push.NewDeliveryPointUpdate(dp)
-			res.Provider = psp
-			res.Content = notif
-			res.Destination = dp
-			resQueue <- res
-		}
-		if msgid, ok := r["message_id"]; ok {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Content = notif
-			res.Destination = dp
-			res.MsgId = fmt.Sprintf("%v:%v", psp.Name(), msgid)
-			resQueue <- res
-		}
-	}
-
-}
-
-func (self *gcmPushService) Push(psp *push.PushServiceProvider, dpQueue <-chan *push.DeliveryPoint, resQueue chan<- *push.PushResult, notif *push.Notification) {
-
-	maxNrDst := 1000
-	dpList := make([]*push.DeliveryPoint, 0, maxNrDst)
-	for dp := range dpQueue {
-		if psp.PushServiceName() != dp.PushServiceName() || psp.PushServiceName() != self.Name() {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Destination = dp
-			res.Content = notif
-			res.Err = push.NewIncompatibleError()
-			resQueue <- res
-			continue
-		}
-		if _, ok := dp.VolatileData["regid"]; ok {
-			dpList = append(dpList, dp)
-		} else if regid, ok := dp.FixedData["regid"]; ok {
-			dp.VolatileData["regid"] = regid
-			dpList = append(dpList, dp)
-		} else {
-			res := new(push.PushResult)
-			res.Provider = psp
-			res.Destination = dp
-			res.Content = notif
-			res.Err = push.NewBadDeliveryPoint(dp)
-			resQueue <- res
-			continue
-		}
-
-		if len(dpList) >= maxNrDst {
-			self.multicast(psp, dpList, resQueue, notif)
-			dpList = dpList[:0]
-		}
-	}
-	if len(dpList) > 0 {
-		self.multicast(psp, dpList, resQueue, notif)
-	}
-
-	close(resQueue)
-}
-
-func (self *gcmPushService) Preview(notif *push.Notification) ([]byte, push.PushError) {
-	return toGCMPayload(notif, []string{"placeholderRegId"})
-}
-
-func (self *gcmPushService) SetErrorReportChan(errChan chan<- push.PushError) {
-	return
 }

--- a/srv/gcm.go
+++ b/srv/gcm.go
@@ -1,5 +1,6 @@
 /*
  * Copyright 2011-2013 Nan Deng
+ * Copyright 2013-2017 Uniqush contributors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,7 +14,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  *
-
  * This contains cloud messaging code specific to GCM.
  * Implementation details common to GCM and FCM are kept in srv/cloud_messaging
  */

--- a/srv/gcm_test.go
+++ b/srv/gcm_test.go
@@ -10,7 +10,10 @@ import (
 func testToGCMPayload(t *testing.T, postData map[string]string, regIds []string, expectedPayload string) {
 	notif := push.NewEmptyNotification()
 	notif.Data = postData
-	payload, err := toGCMPayload(notif, regIds)
+	// Create a push service, just for the sake of realistically testing building payloads
+	stubPushService := newGCMPushService()
+	defer stubPushService.Finalize()
+	payload, err := stubPushService.ToCMPayload(notif, regIds)
 	if err != nil {
 		t.Fatalf("Encountered error %v\n", err)
 	}


### PR DESCRIPTION
Based on PR #139 

This uses anonymous field (in a manner similar to subclassing, but very different) to factor out code common to GCM and FCM http://dennissuratna.com/using-anonymous-field-to-extend-in-go/

- had duplicated code, which would double the work on future changes to GCM/FCM modules and possibly lead to inconsistencies/bugs.
- I recently set up android studio with the FCM mode from https://firebase.google.com/docs/cloud-messaging/android/first-message , and I'm working through the tutorial.
  This will be tested with android devices, GCM on iOS/other may or may not need more work
  Still need to manually call /addpsp, /push, and /subscribe on a local instance of uniqush to test this manually
- Projects used to test this:
  https://firebase.google.com/docs/cloud-messaging/android/first-message 
  https://github.com/firebase/quickstart-android/tree/master/messaging (Getting the token from logcat output)
- The cloud_messaging base class will probably be refactored in future changes, but tests shouldn't need changing