### PR TITLE
Bump version id returned by uniqush /version endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 var uniqushPushConfFlags = flag.String("config", "/etc/uniqush/uniqush-push.conf", "Config file path")
 var uniqushPushShowVersionFlag = flag.Bool("version", false, "Version info")
 
-var uniqushPushVersion = "uniqush-push 2.2.0"
+var uniqushPushVersion = "uniqush-push 2.2.1"
 
 func installPushServices() {
 	srv.InstallGCM()


### PR DESCRIPTION
This includes bumping APNS binary protocol version from 1 to 2
(invisible to clients),
and initial FCM support (pushservicetype=fcm), refactoring GCM to share code with FCM.