### PR TITLE
Remove redundant Name() implementation, convert initialism -> acronym

### DIFF
--- a/srv/cloud_messaging/cloud_messaging.go
+++ b/srv/cloud_messaging/cloud_messaging.go
@@ -48,7 +48,7 @@ type PushServiceBase struct {
 	// (Expose functionality of this client through public methods)
 	client HTTPClient
 	// const: "GCM" or "FCM", for logging
-	acronym string
+	initialism string
 	// const: "uniqush.payload.fcm" or "uniqush.payload.gcm"
 	rawPayloadKey string
 	// const: GCM/FCM endpoint. "https://..../push"
@@ -73,7 +73,7 @@ func (g *PushServiceBase) OverrideClient(client HTTPClient) {
 // Builds a common base.
 // Note: Make sure that this can be copied by value (it's a collection of poitners right now).
 // If it can no longer be copied by value, // change to an initializer function.
-func MakePushServiceBase(acronym string, rawPayloadKey string, serviceURL string, pushServiceName string) PushServiceBase {
+func MakePushServiceBase(initialism string, rawPayloadKey string, serviceURL string, pushServiceName string) PushServiceBase {
 	conf := &tls.Config{InsecureSkipVerify: false}
 	tr := &http.Transport{
 		TLSClientConfig:     conf,
@@ -89,7 +89,7 @@ func MakePushServiceBase(acronym string, rawPayloadKey string, serviceURL string
 	}
 	return PushServiceBase{
 		client:          client,
-		acronym:         acronym,
+		initialism:      initialism,
 		rawPayloadKey:   rawPayloadKey,
 		serviceURL:      serviceURL,
 		pushServiceName: pushServiceName,
@@ -342,7 +342,7 @@ func (self *PushServiceBase) multicast(psp *push.PushServiceProvider, dpList []*
 		res := new(push.PushResult)
 		res.Provider = psp
 		res.Content = notif
-		res.Err = push.NewErrorf("Failed to read %s response: %v", self.acronym, err)
+		res.Err = push.NewErrorf("Failed to read %s response: %v", self.initialism, err)
 		resQueue <- res
 		return
 	}
@@ -354,7 +354,7 @@ func (self *PushServiceBase) multicast(psp *push.PushServiceProvider, dpList []*
 		res := new(push.PushResult)
 		res.Provider = psp
 		res.Content = notif
-		res.Err = push.NewErrorf("Failed to decode %s response: %v", self.acronym, err)
+		res.Err = push.NewErrorf("Failed to decode %s response: %v", self.initialism, err)
 		resQueue <- res
 		return
 	}

--- a/srv/fcm.go
+++ b/srv/fcm.go
@@ -33,8 +33,8 @@ const (
 	fcmServiceURL string = "https://fcm.googleapis.com/fcm/send"
 	// payload key to extract from push requests to uniqush
 	fcmRawPayloadKey = "uniqush.payload.fcm"
-	// acronym for log messages
-	fcmAcronym = "FCM"
+	// initialism for log messages
+	fcmInitialism = "FCM"
 	// push service type(name), for requests to uniqush
 	fcmPushServiceName = "fcm"
 )
@@ -48,7 +48,7 @@ var _ push.PushServiceType = &fcmPushService{}
 
 func newFCMPushService() *fcmPushService {
 	return &fcmPushService{
-		PushServiceBase: cm.MakePushServiceBase(fcmAcronym, fcmRawPayloadKey, fcmServiceURL, fcmPushServiceName),
+		PushServiceBase: cm.MakePushServiceBase(fcmInitialism, fcmRawPayloadKey, fcmServiceURL, fcmPushServiceName),
 	}
 }
 

--- a/srv/fcm_test.go
+++ b/srv/fcm_test.go
@@ -69,3 +69,13 @@ func TestToFCMPayloadUsesMsggroupForCollapseKey(t *testing.T) {
 	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"AMsgGroup","data":{"message":{"aPushType":{"foo":"bar","other":"value"},"fcm":{},"others":{"type":"aPushType"}}},"time_to_live":3600}`
 	testToFCMPayload(t, postData, regIds, expectedPayload)
 }
+
+// Test the return value of Name()
+func TestFCMPushServiceName(t *testing.T) {
+	stubPushService := newFCMPushService()
+	defer stubPushService.Finalize()
+	name := stubPushService.Name()
+	if name != "fcm" {
+		t.Errorf("Expected %s, got %s", "fcm", name)
+	}
+}

--- a/srv/gcm.go
+++ b/srv/gcm.go
@@ -32,8 +32,8 @@ const (
 	gcmServiceURL string = "https://android.googleapis.com/gcm/send"
 	// payload key to extract from push requests to uniqush
 	gcmRawPayloadKey = "uniqush.payload.gcm"
-	// acronym for log messages
-	gcmAcronym = "GCM"
+	// initialism for log messages
+	gcmInitialism = "GCM"
 	// push service type(name), for requests to uniqush
 	gcmPushServiceName = "gcm"
 )
@@ -47,7 +47,7 @@ var _ push.PushServiceType = &gcmPushService{}
 
 func newGCMPushService() *gcmPushService {
 	return &gcmPushService{
-		PushServiceBase: cm.MakePushServiceBase(gcmAcronym, gcmRawPayloadKey, gcmServiceURL, gcmPushServiceName),
+		PushServiceBase: cm.MakePushServiceBase(gcmInitialism, gcmRawPayloadKey, gcmServiceURL, gcmPushServiceName),
 	}
 }
 
@@ -77,8 +77,4 @@ func (p *gcmPushService) BuildPushServiceProviderFromMap(kv map[string]string,
 	}
 
 	return nil
-}
-
-func (p *gcmPushService) Name() string {
-	return "gcm"
 }

--- a/srv/gcm_test.go
+++ b/srv/gcm_test.go
@@ -69,3 +69,13 @@ func TestToGCMPayloadUsesMsggroupForCollapseKey(t *testing.T) {
 	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"AMsgGroup","data":{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}},"time_to_live":3600}`
 	testToGCMPayload(t, postData, regIds, expectedPayload)
 }
+
+// Test the return value of Name()
+func TestGCMPushServiceName(t *testing.T) {
+	stubPushService := newGCMPushService()
+	defer stubPushService.Finalize()
+	name := stubPushService.Name()
+	if name != "gcm" {
+		t.Errorf("Expected %s, got %s", "gcm", name)
+	}
+}


### PR DESCRIPTION
The Name() was included in srv/cloud_messaging/,
having each service override it is confusing and redundant.