### PR TITLE
Update the travis CI version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 language: go
 
+# Compile with the latest OS image (previously 12.04, now 14.04)
+# `sudo: required` is the default for repositories enabled before 2015 (we don't need it and it's slower)
+dist: trusty
+sudo: false
+
 # Compile with the latest version of go.
 go:
   - tip


### PR DESCRIPTION
Benefits: faster Travis CI runs, more up to date libraries.
(Not very important since golang produces static binaries)