### PR TITLE
Use unescaped JSON for payloads. Stricten CI checks.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,6 @@ go:
 # install step default is `go get ./...`
 # script default is `go test ./...`
 # (Could include apns-test.sh, but that doesn't have expected output written yet)
+script:
+  - go tool vet -printfuncs debugf,infof,configf,warnf,errorf,alertf,fatalf .
+  - go test ./... -race

--- a/srv/cloud_messaging/cloud_messaging.go
+++ b/srv/cloud_messaging/cloud_messaging.go
@@ -34,6 +34,7 @@ import (
 	"time"
 
 	"github.com/uniqush/uniqush-push/push"
+	"github.com/uniqush/uniqush-push/util"
 )
 
 // HTTPClient is a mockable interface for the parts of http.Client used by the GCM and FCM modules.
@@ -207,7 +208,7 @@ func (self *PushServiceBase) ToCMPayload(notif *push.Notification, regIds []stri
 		}
 	}
 
-	jpayload, e0 := json.Marshal(payload)
+	jpayload, e0 := util.MarshalJSONUnescaped(payload)
 	if e0 != nil {
 		return nil, push.NewErrorf("Error converting payload to JSON: %v", e0)
 	}
@@ -288,7 +289,7 @@ func (self *PushServiceBase) multicast(psp *push.PushServiceProvider, dpList []*
 				res.Err = push.NewRetryErrorWithReason(psp, dp, notif, after, err)
 
 			} else {
-				res.Err = push.NewErrorf("Unrecoverable HTTP error sending to FCM: %v", e2)
+				res.Err = push.NewErrorf("Unrecoverable HTTP error sending to GFC/FCM: %v", e2)
 			}
 			resQueue <- res
 		}
@@ -393,7 +394,7 @@ func (self *PushServiceBase) handleCMMulticastResults(psp *push.PushServiceProvi
 				resQueue <- res
 			default:
 				res := new(push.PushResult)
-				res.Err = push.NewErrorf("FCMError: %v", errmsg)
+				res.Err = push.NewErrorf("GCM/FCMError: %v", errmsg)
 				res.Provider = psp
 				res.Content = notif
 				res.Destination = dp

--- a/srv/fcm_push_service_test.go
+++ b/srv/fcm_push_service_test.go
@@ -145,7 +145,7 @@ func fcmTestPushSingleError(t *testing.T) {
 		}
 		err, ok := res.Err.(*push.BadPushServiceProvider)
 		if !ok {
-			t.Fatalf("Expected type BadPushServiceProvider, got %t", err)
+			t.Fatalf("Expected type BadPushServiceProvider, got %T", err)
 		}
 		if res.Provider != psp {
 			t.Errorf("Unexpected psp %v in BadPushServiceProvider result", err.Provider)

--- a/srv/gcm_push_service_test.go
+++ b/srv/gcm_push_service_test.go
@@ -145,7 +145,7 @@ func TestPushSingleError(t *testing.T) {
 		}
 		err, ok := res.Err.(*push.BadPushServiceProvider)
 		if !ok {
-			t.Fatalf("Expected type BadPushServiceProvider, got %t", err)
+			t.Fatalf("Expected type BadPushServiceProvider, got %T", err)
 		}
 		if res.Provider != psp {
 			t.Errorf("Unexpected psp %v in BadPushServiceProvider result", err.Provider)

--- a/srv/gcm_test.go
+++ b/srv/gcm_test.go
@@ -33,6 +33,17 @@ func TestToGCMPayloadWithRawPayload(t *testing.T) {
 	testToGCMPayload(t, postData, regIds, expectedPayload)
 }
 
+func TestToGCMPayloadWithRawUnescapedPayload(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":            "somegroup",
+		"uniqush.payload.gcm": `{"message":{"key": {},"x":"<a☃?>\"'"},"other":{}}`,
+		"foo": "bar",
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"message":{"key":{},"x":"<a☃?>\"'"},"other":{}},"time_to_live":3600}`
+	testToGCMPayload(t, postData, regIds, expectedPayload)
+}
+
 func TestToGCMPayloadWithCommonParameters(t *testing.T) {
 	postData := map[string]string{
 		"msggroup":  "somegroup",

--- a/util/json.go
+++ b/util/json.go
@@ -1,0 +1,63 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+)
+
+// extractToken takes the remainder of a JSON-encoded string. It removes a token, converting html escaped tokens to the equivalent non-escaped token.
+func extractToken(s string) (remainder string, token string) {
+	// convert instances of \u00xy to a single character.
+	n := len(s)
+	if n < 6 {
+		return "", s
+	}
+	if s[0] != '\\' {
+		return s[1:], s[0:1]
+	}
+	// two backslashes, `\t`, etc. should be a single token. Don't care about "\\x.."
+	if s[1] != 'u' {
+		return s[2:], s[0:2]
+	}
+
+	// s begins with the 4 bytes `\u00`, the remainder is a unicode escape code.
+	remainder = s[6:]
+	if s[2] == '0' && s[3] == '0' {
+		switch s[4:6] {
+		case "22":
+			token = "\\\""
+		case "26":
+			token = "&"
+		case "3c":
+			token = "<"
+		case "3e":
+			token = ">"
+		default:
+			token = s[:6]
+		}
+	} else {
+		token = s[:6]
+	}
+	return remainder, token
+}
+
+// MarshalJSONUnescaped undoes the HTML escaping done by encoding/json.
+func MarshalJSONUnescaped(v interface{}) ([]byte, error) {
+	// Get the HTML escaped
+	b, err := json.Marshal(v)
+	if err != nil {
+		return nil, err
+	}
+	s := string(b)
+	if !strings.Contains(s, "\\u00") {
+		return b, nil
+	}
+	buf := &bytes.Buffer{}
+	for len(s) > 0 {
+		var token string
+		s, token = extractToken(s)
+		buf.WriteString(token)
+	}
+	return buf.Bytes(), nil
+}

--- a/util/json_test.go
+++ b/util/json_test.go
@@ -1,0 +1,35 @@
+package util
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+)
+
+// TestMarshalJSONUnescaped tests that HTML encoding is properly removed from json.Marshal, so that APNS receives a payload it supports.
+func TestMarshalJSONUnescaped(t *testing.T) {
+	testValues := []string{
+		`null`,              // Null
+		`{"a":"\\u003c"}`,   // Double backslashes, not an escape sequence in json
+		`{"a":"\\\\u003c"}`, // Quadruple backslashes, not an escape sequence in json
+		`{"a":"\u0019"}`,    // An ASCII control code. Keep it escaped.
+		`{"<a":"<&>"}`,
+		`"<&>\""`,
+		`{"a":">\""}`, // A quotation mark. Should use backslashes to escape instead of unicode escape sequence
+		`{"a":"\u0000\u0001\u0002\u0003\u0004\u0005\u0006\u0007\u0008\t\n\u000b\u000c\r\u000e\u000f\u0010\u0011\u0012\u0013\u0014\u0015\u0016\u0017\u0018\u0019\u001a\u001b\u001c\u001d\u001e\u001f !\"#$%&'()*+,-.\\/0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[]^_abcdefghijklmnopqrstuvwxyz{|}~"}`,
+		`{"a":"한국어/조선말"}`, // unicode should continue to work.
+	}
+
+	for _, testValue := range testValues {
+		var data interface{}
+		originalBytes := []byte(testValue)
+		err := json.Unmarshal(originalBytes, &data)
+		if err != nil {
+			t.Fatalf("Invalid test value %q: %v", testValue, err)
+		}
+		reencoded, err := MarshalJSONUnescaped(data)
+		if !bytes.Equal(reencoded, originalBytes) {
+			t.Errorf("Expected %v(%s), got %v(%s)", originalBytes, testValue, reencoded, string(reencoded))
+		}
+	}
+}


### PR DESCRIPTION
otherwise, "<" is needlessly escaped
(Not intended to ever render this as HTML)

Unescaped JSON reduces the size of GCM payloads,
and prevents the size from increasing when providing raw gcm/fcm payloads.

Analyze format strings of expressions such as log.Configf from
uniqush-log

Use race condition checker when running travis CI tests.