### PR TITLE
For #177 : Support GCM&FCM "notification" payloads.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ language: go
 dist: trusty
 sudo: false
 
-# Compile with go 1.8.3 (or newer). It takes a long time to install `tip`
+# Compile with go 1.9 (or newer). It takes a long time to install `tip`
 go:
-  - 1.8.3
+  - 1.9
 
 # install step default is `go get ./...`
 # script default is `go test ./...`

--- a/srv/fcm.go
+++ b/srv/fcm.go
@@ -31,8 +31,11 @@ import (
 const (
 	// FCM endpoint
 	fcmServiceURL string = "https://fcm.googleapis.com/fcm/send"
-	// payload key to extract from push requests to uniqush
+	// payload key to extract from push requests to uniqush. The corresponding value is a JSON blob for a FCM data push
+	// (silent, unless the app has logic to extract information to display notifications on the device)
 	fcmRawPayloadKey = "uniqush.payload.fcm"
+	// notification key to extract from push requests to uniqush. The corresponding value is a JSON blob for a FCM notification (alerts user)
+	fcmRawNotificationKey = "uniqush.notification.fcm"
 	// initialism for log messages
 	fcmInitialism = "FCM"
 	// push service type(name), for requests to uniqush
@@ -48,7 +51,7 @@ var _ push.PushServiceType = &fcmPushService{}
 
 func newFCMPushService() *fcmPushService {
 	return &fcmPushService{
-		PushServiceBase: cm.MakePushServiceBase(fcmInitialism, fcmRawPayloadKey, fcmServiceURL, fcmPushServiceName),
+		PushServiceBase: cm.MakePushServiceBase(fcmInitialism, fcmRawPayloadKey, fcmRawNotificationKey, fcmServiceURL, fcmPushServiceName),
 	}
 }
 

--- a/srv/gcm.go
+++ b/srv/gcm.go
@@ -30,8 +30,11 @@ import (
 const (
 	// GCM endpoint
 	gcmServiceURL string = "https://android.googleapis.com/gcm/send"
-	// payload key to extract from push requests to uniqush
+	// payload key to extract from push requests to uniqush. The corresponding value is a JSON blob for a GCM data
+	// (silent, unless the app has logic to extract information to display notifications on the device)
 	gcmRawPayloadKey = "uniqush.payload.gcm"
+	// notification key to extract from push requests to uniqush. The corresponding value is a JSON blob for a GCM notification (alerts user)
+	gcmRawNotificationKey = "uniqush.notification.gcm"
 	// initialism for log messages
 	gcmInitialism = "GCM"
 	// push service type(name), for requests to uniqush
@@ -47,7 +50,7 @@ var _ push.PushServiceType = &gcmPushService{}
 
 func newGCMPushService() *gcmPushService {
 	return &gcmPushService{
-		PushServiceBase: cm.MakePushServiceBase(gcmInitialism, gcmRawPayloadKey, gcmServiceURL, gcmPushServiceName),
+		PushServiceBase: cm.MakePushServiceBase(gcmInitialism, gcmRawPayloadKey, gcmRawNotificationKey, gcmServiceURL, gcmPushServiceName),
 	}
 }
 

--- a/srv/gcm_push_service_test.go
+++ b/srv/gcm_push_service_test.go
@@ -227,7 +227,7 @@ func TestPreviewWithCommonParameters(t *testing.T) {
 		"uniqush.payload.apns": "{}",
 		"uniqush.foo":          "foo",
 	}
-	expectedPayload := `{"registration_ids":["placeholderRegId"],"collapse_key":"somegroup","data":{"other":"value","other.foo":"bar"},"time_to_live":5}`
+	expectedPayload := `{"registration_ids":["placeholderRegId"],"collapse_key":"somegroup","time_to_live":5,"data":{"other":"value","other.foo":"bar"}}`
 
 	notif := push.NewEmptyNotification()
 	notif.Data = postData

--- a/srv/gcm_test.go
+++ b/srv/gcm_test.go
@@ -8,6 +8,7 @@ import (
 )
 
 func testToGCMPayload(t *testing.T, postData map[string]string, regIds []string, expectedPayload string) {
+	t.Helper()
 	notif := push.NewEmptyNotification()
 	notif.Data = postData
 	// Create a push service, just for the sake of realistically testing building payloads
@@ -26,10 +27,20 @@ func TestToGCMPayloadWithRawPayload(t *testing.T) {
 	postData := map[string]string{
 		"msggroup":            "somegroup",
 		"uniqush.payload.gcm": `{"message":{"key": {},"x":"y"},"other":{}}`,
-		"foo": "bar",
+		"foo": "bar", // ignored
 	}
 	regIds := []string{"CAFE1-FF", "42-607"}
-	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"message":{"key":{},"x":"y"},"other":{}},"time_to_live":3600}`
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","time_to_live":3600,"data":{"message":{"key":{},"x":"y"},"other":{}}}`
+	testToGCMPayload(t, postData, regIds, expectedPayload)
+}
+
+func TestToGCMPayloadWithRawEmptyPayload(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":            "somegroup",
+		"uniqush.payload.gcm": `{}`,
+	}
+	regIds := []string{"CAFE1-FF", "42-607"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","time_to_live":3600,"data":{}}`
 	testToGCMPayload(t, postData, regIds, expectedPayload)
 }
 
@@ -40,7 +51,7 @@ func TestToGCMPayloadWithRawUnescapedPayload(t *testing.T) {
 		"foo": "bar",
 	}
 	regIds := []string{"CAFE1-FF", "42-607"}
-	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"message":{"key":{},"x":"<a☃?>\"'"},"other":{}},"time_to_live":3600}`
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","time_to_live":3600,"data":{"message":{"key":{},"x":"<a☃?>\"'"},"other":{}}}`
 	testToGCMPayload(t, postData, regIds, expectedPayload)
 }
 
@@ -51,7 +62,7 @@ func TestToGCMPayloadWithCommonParameters(t *testing.T) {
 		"foo": "bar",
 	}
 	regIds := []string{"CAFE1-FF", "42-607"}
-	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"message":{"key":{},"x":"<a☃?>\"'"},"other":{}},"time_to_live":3600}`
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","time_to_live":3600,"data":{"message":{"key":{},"x":"<a☃?>\"'"},"other":{}}}`
 	testToGCMPayload(t, postData, regIds, expectedPayload)
 }
 
@@ -66,18 +77,18 @@ func TestToGCMPayloadWithCommonParametersV2(t *testing.T) {
 		"uniqush.foo":          "foo",
 	}
 	regIds := []string{"CAFE1-FF", "42-607"}
-	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"other":"value","other.foo":"bar"},"time_to_live":5}`
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","time_to_live":5,"data":{"other":"value","other.foo":"bar"}}`
 	testToGCMPayload(t, postData, regIds, expectedPayload)
 }
 
 // Test that it will be encoded properly if uniqush.payload.gcm is provided instead of uniqush.payload
-func TestToGCMPayloadNewWay(t *testing.T) {
+func TestToGCMPayloadWithBlob(t *testing.T) {
 	postData := map[string]string{
-		"msggroup":            "somegroup",
+		"msggroup":            "somegroupnotif",
 		"uniqush.payload.gcm": `{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}}`,
 	}
 	regIds := []string{"CAFE1-FF", "42-607"}
-	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroup","data":{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}},"time_to_live":3600}`
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"somegroupnotif","time_to_live":3600,"data":{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}}}`
 	testToGCMPayload(t, postData, regIds, expectedPayload)
 }
 
@@ -88,7 +99,30 @@ func TestToGCMPayloadUsesMsggroupForCollapseKey(t *testing.T) {
 		"msggroup":            "AMsgGroup",
 	}
 	regIds := []string{"CAFE1-FF", "42-607"}
-	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"AMsgGroup","data":{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}},"time_to_live":3600}`
+	expectedPayload := `{"registration_ids":["CAFE1-FF","42-607"],"collapse_key":"AMsgGroup","time_to_live":3600,"data":{"message":{"aPushType":{"foo":"bar","other":"value"},"gcm":{},"others":{"type":"aPushType"}}}}`
+	testToGCMPayload(t, postData, regIds, expectedPayload)
+}
+
+// Test that it will be encoded properly if uniqush.notification.gcm is provided
+func TestToGCMNotificationWithBlob(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":                 "somegroup",
+		"uniqush.notification.gcm": `{"body":"text","icon":"myicon","title":"🔥Notification Title"}`,
+	}
+	regIds := []string{"CAFE1-FF", "11-213"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","11-213"],"collapse_key":"somegroup","time_to_live":3600,"notification":{"body":"text","icon":"myicon","title":"🔥Notification Title"}}`
+	testToGCMPayload(t, postData, regIds, expectedPayload)
+}
+
+// Test that it will be encoded properly if uniqush.notification.gcm and uniqush.notification.fcm are provided
+func TestToGCMNotificationWithPayloadAndNotificationBlobs(t *testing.T) {
+	postData := map[string]string{
+		"msggroup":                 "bothgroup",
+		"uniqush.notification.gcm": `{"body":"text","icon":"myicon","title":"mytitle"}`,
+		"uniqush.payload.gcm":      `{"message":{"key": {},"x":"y"},"other":{}}`,
+	}
+	regIds := []string{"CAFE1-FF", "11-213"}
+	expectedPayload := `{"registration_ids":["CAFE1-FF","11-213"],"collapse_key":"bothgroup","time_to_live":3600,"data":{"message":{"key":{},"x":"y"},"other":{}},"notification":{"body":"text","icon":"myicon","title":"mytitle"}}`
 	testToGCMPayload(t, postData, regIds, expectedPayload)
 }
 


### PR DESCRIPTION
To start with, do the simplest possible thing and
allow users to provide these as a JSON blob over the REST API.
- E.g. the following (clients should obviously URL encode the values)
  uniqush.payload.fcm={"title":"MyTitle","body":"NotifBodyText"}

See the following links

- https://firebase.google.com/docs/cloud-messaging/concept-options#notifications_and_data_messages
-https://developers.google.com/cloud-messaging/concept-options#notifications_and_data_messages

"notification" payloads are rendered directly on the device by GCM,
without needing the client apps to do anything (similar to APNS).

On a tangent, APNS now has silent notifications, and uniqush doesn't
support those yet.

Example
-------

Start a server

```
$ ./uniqush-push -config conf/uniqush-push.conf
[WebFrontend][Config] 2017/10/02 22:18:22 [Start] localhost:9898
```

Preview what Uniqush would send to FCM for the corresponding /push,
within the field "payload" of the response (similar for GCM)

```
$ curl http://127.0.0.1:9898/previewpush \
    -d pushservicetype=fcm \
    -d 'uniqush.notification.fcm={"title":"my title","body":"notification body"}' \
    -d ttl=5
{"code":"UNIQUSH_SUCCESS","payload":{"notification":{"body":"notification body","title":"my title"},"registration_ids":["placeholderRegId"],"time_to_live":5}}
```

The push format is documented at the following links:

- https://developers.google.com/cloud-messaging/http-server-ref
- https://firebase.google.com/docs/cloud-messaging/http-server-ref#downstream-http-messages-json