### PR TITLE
Update uniqush's version to 2.4.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 var uniqushPushConfFlags = flag.String("config", "/etc/uniqush/uniqush-push.conf", "Config file path")
 var uniqushPushShowVersionFlag = flag.Bool("version", false, "Version info")
 
-var uniqushPushVersion = "uniqush-push 2.3.0"
+var uniqushPushVersion = "uniqush-push 2.4.0"
 
 func installPushServices() {
 	srv.InstallGCM()


### PR DESCRIPTION
New features:

- Initial support for GCM/FCM "notification" pushes (Documented in PR #185).
  `uniqush.notification.gcm` and `uniqush.notification.fcm` can be used
  as fields for `/push`, with the JSON blob to send GCM/FCM for the
  optional "notification" message.
  "notification" messages will let GCM/FCM display the notification for you.

Maintenance:
- Change from https://android.googleapis.com/gcm/send to
  https://gcm-http.googleapis.com/gcm/send
- Bump go version used to compile releases

Bug fixes:
- Improve logging subscriber name in failed API requests.