### PR TITLE
Move goconf dependency to uniqush github project

### DIFF
--- a/configparser.go
+++ b/configparser.go
@@ -22,7 +22,7 @@ import (
 	"os"
 	"strings"
 
-	"github.com/ifwe/goconf/conf"
+	"github.com/uniqush/goconf/conf"
 	"github.com/uniqush/log"
 	"github.com/uniqush/uniqush-push/db"
 	"github.com/uniqush/uniqush-push/push"


### PR DESCRIPTION
The contents are identical. ifwe/goconf isn't used elsewhere.

Closes #183