### PR TITLE
Update AddPushServiceProviderToService method to prevent duplicate se…

### DIFF
--- a/db/pushdb.go
+++ b/db/pushdb.go
@@ -145,11 +145,36 @@ func (f *pushDatabaseOpts) AddPushServiceProviderToService(service string,
 	}
 	f.dblock.Lock()
 	defer f.dblock.Unlock()
+
+	//Service can have multiple psp in different push service type, but user might add redundant psp(different setting) with same service name. Under this situation, only one service will be used for subsribe and push in runtime.
+	//Unfortunately, no one know which psp will be used in subscribe and push later, only the very first one returned from getting psp2srv api will be used. That's a bug.
+	//So the new service psp with duplicate push type should be added. It will be verified before ADD.
+	expsps, err := f.db.GetPushServiceProvidersByService(service)
+	if err != nil {
+		return fmt.Errorf("Error querying psp with name: %v", err)
+	}
+	if len(expsps) > 0 {
+		for index := range expsps {
+			pushpsp, perr := f.db.GetPushServiceProvider(expsps[index])
+
+			if perr != nil {
+				return fmt.Errorf("Error to retrieve psp with name: %v", err)
+			}
+			//Whether the existing psp has the same push service type
+			if pushpsp.PushServiceName() == push_service_provider.PushServiceName() {
+				//The service has a psp in same push service type
+				return fmt.Errorf("Unable to add the service %s due to dulicate Push Service Provider in same type. New psp detail: %v", service, push_service_provider)
+			}
+		}
+
+	}
+
 	e := f.db.SetPushServiceProvider(push_service_provider)
 	if e != nil {
 		return fmt.Errorf("Error associating psp with name: %v", e)
 	}
 	return f.db.AddPushServiceProviderToService(service, push_service_provider.Name())
+
 }
 
 func (f *pushDatabaseOpts) AddDeliveryPointToService(service string,


### PR DESCRIPTION
Currently, one service is allowed to have multiple psp during ADDPSP.  Notice there is comment mentioned that it's a feature to allow single service has multiple psp in different push service type. Unfortunately, sometimes a user might add a service psp in same push service type,  since there is no warning message for that, under this situation, no one even know there are multiple service<->psp pair in same push service type, and only the very first one returned in getting service will be working in runtime. That will cause trouble in subscribe and push operation.   It results in some issues and hard to discover the root cause.  So introducing this fix to prevent a user to add redundant service<->psp in same push service type.   
One method AddPushServiceProviderToService(...) in pushdb.go is updated to fix this issue. And psp in different push service type is still allowed to add under the same service.