### PR TITLE
Allow empty strings in APNS loc-args and title-loc-args ("loc-args=,arg1" is now treated as 2 args)

### DIFF
--- a/srv/apns/payload.go
+++ b/srv/apns/payload.go
@@ -126,9 +126,7 @@ func parseList(str string) []string {
 		} else if r == '\\' {
 			escape = true
 		} else if r == ',' {
-			if len(elem) > 0 {
-				ret = append(ret, string(elem))
-			}
+			ret = append(ret, string(elem))
 			elem = elem[:0]
 		} else {
 			elem = append(elem, r)


### PR DESCRIPTION
Currently, you can't add empty strings to the loc-args array. What bothers me is that it just silently ignores the empty string, which could possibly break template implementations as a arg on index 4 would suddenly be on index 3.
 