### PR TITLE
Fix bug in checks of payload size, add uniqush.apns_voip=1 option.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ _testmain.go
 _cgo_*
 _obj
 _test
+uniqush-push

--- a/srv/apns/binary_api/processor.go
+++ b/srv/apns/binary_api/processor.go
@@ -269,10 +269,6 @@ func (self *BinaryPushRequestProcessor) singlePush(payload, token []byte, expiry
 // multiPush calls singlePush in parallel for each token type in Devtokens, and waits for each singlePush to complete.
 func (self *BinaryPushRequestProcessor) multiPush(req *common.PushRequest, workerpool *Pool) {
 	defer close(req.ErrChan)
-	if len(req.Payload) > self.GetMaxPayloadSize() {
-		req.ErrChan <- push.NewBadNotificationWithDetails("payload is too large")
-		return
-	}
 
 	n := len(req.Devtokens)
 	wg := new(sync.WaitGroup)

--- a/srv/apns/payload.go
+++ b/srv/apns/payload.go
@@ -113,9 +113,6 @@ func toAPNSPayload(n *push.Notification) ([]byte, push.PushError) {
 	if err != nil {
 		return nil, push.NewErrorf("Failed to convert notification data to JSON: %v", err)
 	}
-	if len(j) > maxPayLoadSize {
-		return nil, push.NewBadNotificationWithDetails("payload is too large")
-	}
 	return j, nil
 }
 

--- a/srv/apns/push_service_test.go
+++ b/srv/apns/push_service_test.go
@@ -204,6 +204,8 @@ func TestPushMultiple(t *testing.T) {
 	service.Finalize()
 }
 
+// TODO: Add tests of uniqush generating expected errors for the various payload size limits. (2048 for binary, 4096 for HTTP2, 5120 for VoIP + HTTP2
+
 // TestPushUnsubscribe tests that an UnsubscribeUpdate should be generated from the corresponding apns status code.
 func TestPushUnsubscribe(t *testing.T) {
 	expectedContentId := 2223511


### PR DESCRIPTION
Get rid of a leftover check that was accidentally limiting
some APNS HTTP2 payloads to 2KB.
The check is needed in only one place; that place is
srv/apns/push_service.go

This check is duplicated in srv/apns/http_api/processor.go and
srv/apns/binary_api/processor.go

When uniqush.apns_voip=1 is passed to /push alongside uniqush.http2=1,
limit the payload size

For #202