### PR TITLE
Release uniqush-push 2.5.0

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 var uniqushPushConfFlags = flag.String("config", "/etc/uniqush/uniqush-push.conf", "Config file path")
 var uniqushPushShowVersionFlag = flag.Bool("version", false, "Version info")
 
-var uniqushPushVersion = "uniqush-push 2.4.0"
+var uniqushPushVersion = "uniqush-push 2.5.0"
 
 func installPushServices() {
 	srv.InstallGCM()


### PR DESCRIPTION
- Support "title", "title-loc-key", and "title-loc-args"
- Support larger APNS payloads.
  Support 5120 byte payloads for APNS voip pushes
  (Where the Cert is a VOIP cert and `uniqush.apns_voip=1` is part of
  the query params in the call to /push
- Support more granular loglevel levels in uniqush config files:
  alert, error, warn/warning, standard/verbose/info, and debug