### PR TITLE
Change the GCM endpoint to FCM (For Issue #210)

### DIFF
--- a/main.go
+++ b/main.go
@@ -29,7 +29,7 @@ import (
 var uniqushPushConfFlags = flag.String("config", "/etc/uniqush/uniqush-push.conf", "Config file path")
 var uniqushPushShowVersionFlag = flag.Bool("version", false, "Version info")
 
-var uniqushPushVersion = "uniqush-push 2.5.0"
+var uniqushPushVersion = "uniqush-push 2.5.1-dev"
 
 func installPushServices() {
 	srv.InstallGCM()

--- a/srv/gcm.go
+++ b/srv/gcm.go
@@ -28,8 +28,8 @@ import (
 )
 
 const (
-	// GCM endpoint
-	gcmServiceURL string = "https://gcm-http.googleapis.com/gcm/send"
+	// GCM endpoint (FCM can be used to push GCM subscriptions. gcm-http.googleapis.com/gcm/ will be decommissioned in april 2019)
+	gcmServiceURL string = "https://fcm.googleapis.com/fcm/send"
 	// payload key to extract from push requests to uniqush. The corresponding value is a JSON blob for a GCM data
 	// (silent, unless the app has logic to extract information to display notifications on the device)
 	gcmRawPayloadKey = "uniqush.payload.gcm"


### PR DESCRIPTION
This has been tested with a prod and testing version
of an application using `uniqush-push`.

This will not have any impact on how uniqush represents
or updates the subscriber database for a GCM application.
(Future PRs may or may not update GCM subscriptions, e.g. on an as-needed basis or if a migration is started)

No issues were found. Pushes went through,
and the subscription did not have any unexpected behavior
(e.g. did not get unregistered as a side effect)

This will be necessary when GCM servers are decommissioned on April 2019.