### PR TITLE
Update go-redis from v5 to v6 (master)

### DIFF
--- a/db/pushdb_test.go
+++ b/db/pushdb_test.go
@@ -22,7 +22,7 @@ import (
 	"strconv"
 	"testing"
 
-	redis5 "gopkg.in/redis.v5"
+	"github.com/go-redis/redis"
 )
 
 var dbconf *DatabaseConfig
@@ -55,7 +55,7 @@ func clearData() {
 	if err != nil {
 		db = 0
 	}
-	client := redis5.NewClient(&redis5.Options{
+	client := redis.NewClient(&redis.Options{
 		Addr:     fmt.Sprintf("%s:%d", c.Host, c.Port),
 		Password: c.Password,
 		DB:       int(db),


### PR DESCRIPTION
The dependency now recommends using github.com/go-redis/redis.

apns-test.sh continues to work normally against a locally running redis
instance