### PR TITLE
Release uniqush-push 2.6.1.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,14 +1,17 @@
 uniqush-push NEWS
 
-?? ??? 2018, uniqush-push 2.6.1 (dev)
+21 Jul 2018, uniqush-push 2.6.1
 -------------------------------
 
-- Maintenance: Fix various code style warnings from code linters.
-- Bugfix: Fix "No device" errors seen when retrying a push. (PR #222)
+- Maintenance: Fix various code style warnings from code linters (e.g. gometalinter). Refactor and document code.
+- Bugfix: Fix the rare "No device" errors seen when retrying a push. (PR #222)
 - Bugfix: Fix the regular expression used as a sanity check of subscriptions and services. (PR #222)
   The intended accepted characters for use in services and subscriptions were `a-z, A-Z, 0-9, -, _, @ or .`
 
   Forbid using the backtick in service and subscription names (this was accidentally permitted by the invalid regex).
+
+  Continue allowing a small number of other invalid characters for now,
+  those may be deprecated in future releases.
 
 18 Jul 2018, uniqush-push 2.6.0
 -------------------------------

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ import (
 var uniqushPushConfFlags = flag.String("config", "/etc/uniqush/uniqush-push.conf", "Config file path")
 var uniqushPushShowVersionFlag = flag.Bool("version", false, "Version info")
 
-var uniqushPushVersion = "uniqush-push 2.6.1-dev"
+var uniqushPushVersion = "uniqush-push 2.6.1"
 
 func installPushServices() {
 	srv.InstallGCM()


### PR DESCRIPTION
Most of the changes are fixes for linter warnings or notices.

Notable changes:

- Bugfix: Fix the rare "No device" errors seen when retrying a push.
  (PR #222)
- Bugfix: Fix the regular expression used as a sanity check of
  subscriptions and services. (PR #222)
  The intended accepted characters for use in services and
  subscriptions were `a-z, A-Z, 0-9, -, _, @ or .`

  Forbid using the backtick in service and subscription names
  (this was accidentally permitted by the invalid regex).

  Continue allowing a small number other invalid characters for now,
  those may be deprecated in future releases.